### PR TITLE
Honor two-word pacman options

### DIFF
--- a/src/Aura/Flags.hs
+++ b/src/Aura/Flags.hs
@@ -26,6 +26,7 @@ module Aura.Flags
     , reconvertFlags
     , dualFlagMap
     , hijackedFlagMap
+    , pacmanFlagMap
     , buildABSDepsStatus
     , confirmationStatus
     , customizepkgStatus
@@ -120,13 +121,16 @@ data Flag = ABSInstall
           | ItalianOut
           | SerbianOut
           | NorwegiOut
+          | PacmanArg String String
             deriving (Eq,Ord,Show)
 
 allFlags :: Language -> [OptDescr Flag]
 allFlags lang = concat [ auraOperations lang
                        , auraOptions
                        , pacmanOptions
-                       , dualOptions ]
+                       , dualOptions
+                       , languageOptions
+                       , longPacmanOptions ]
 
 simpleOption :: (String,[String],Flag) -> OptDescr Flag
 simpleOption (c,s,f) = Option c s (NoArg f) ""
@@ -192,6 +196,21 @@ dualOptions = Option [] ["ignore"]      (ReqArg Ignore      "" ) "" :
               [ ( [], ["noconfirm"], NoConfirm )
               , ( [], ["needed"],    Needed    ) ]
 
+-- These Pacman options are ignored,
+-- but parser needs to know that they require an argument
+longPacmanOptions :: [OptDescr Flag]
+longPacmanOptions = map pacArg
+                    [ "dbpath", "root", "arch", "cachedir", "color"
+                    , "config", "gpgdir" , "logfile", "assume-installed"
+                    , "print-format" ]
+                    -- "owns" is apparently okay as is?
+                    -- TODO: check all others
+    where pacArg option = Option [] [option] (ReqArg (PacmanArg option) "") ""
+
+pacmanFlagMap :: FlagMap
+pacmanFlagMap (PacmanArg option arg) = "--" ++ option ++ "=" ++ arg
+pacmanFlagMap _                      = ""
+
 languageOptions :: [OptDescr Flag]
 languageOptions = map simpleOption
                   [ ( [], ["japanese","日本語"],      JapOut      )
@@ -246,12 +265,13 @@ settingsFlags = [ Unsuppress,NoConfirm,HotEdit,DiffPkgbuilds,Debug,Devel
 -- Flags like `AURIgnore` and `BuildPath` have args, and thus can't be included
 -- in the `settingsFlags` list.
 notSettingsFlag :: Flag -> Bool
-notSettingsFlag (AURIgnore _) = False
-notSettingsFlag (BuildPath _) = False
-notSettingsFlag (BuildUser _) = False
-notSettingsFlag (TruncHead _) = False
-notSettingsFlag (TruncTail _) = False
-notSettingsFlag f             = f `notElem` settingsFlags
+notSettingsFlag (AURIgnore _)   = False
+notSettingsFlag (BuildPath _)   = False
+notSettingsFlag (BuildUser _)   = False
+notSettingsFlag (TruncHead _)   = False
+notSettingsFlag (TruncTail _)   = False
+notSettingsFlag (PacmanArg _ _) = False
+notSettingsFlag f               = f `notElem` settingsFlags
 
 auraOperMsg :: Language -> String
 auraOperMsg lang = usageInfo (yellow $ auraOperTitle lang) $ auraOperations lang
@@ -339,8 +359,8 @@ makepkgFlags = fishOutFlag [(IgnoreArch,["--ignorearch"])] []
 
 parseLanguageFlag :: [String] -> (Maybe Language,[String])
 parseLanguageFlag args =
-    case getOpt' Permute languageOptions args of
-      (langs,nonOpts,otherOpts,_) -> (getLanguage langs, nonOpts ++ otherOpts)
+    case getOpt Permute languageOptions args of
+      (langs,nonOpts,_) -> (getLanguage langs, nonOpts)
 
 -- I don't like this.
 parseFlags :: Maybe Language -> [String] -> ([Flag],[String],[String])

--- a/src/Aura/Flags.hs
+++ b/src/Aura/Flags.hs
@@ -199,13 +199,15 @@ dualOptions = Option [] ["ignore"]      (ReqArg Ignore      "" ) "" :
 -- These Pacman options are ignored,
 -- but parser needs to know that they require an argument
 longPacmanOptions :: [OptDescr Flag]
-longPacmanOptions = map pacArg
+longPacmanOptions = map pacArg $ zip
                     [ "dbpath", "root", "arch", "cachedir", "color"
                     , "config", "gpgdir" , "logfile", "assume-installed"
                     , "print-format" ]
+                    ( "b" : "r" : repeat [] )
                     -- "owns" is apparently okay as is?
                     -- TODO: check all others
-    where pacArg option = Option [] [option] (ReqArg (PacmanArg option) "") ""
+    where pacArg (option, letter) = Option letter [option]
+                                    (ReqArg (PacmanArg option) "") ""
 
 pacmanFlagMap :: FlagMap
 pacmanFlagMap (PacmanArg option arg) = "--" ++ option ++ "=" ++ arg

--- a/src/aura.hs
+++ b/src/aura.hs
@@ -68,9 +68,10 @@ main = getArgs >>= prepSettings . processFlags >>= execute >>= exit
 
 processFlags :: [String] -> (UserInput,Maybe Language)
 processFlags args = ((flags,nub input,pacOpts'),language)
-    where (language,rest) = parseLanguageFlag args
-          (flags,input,pacOpts) = parseFlags language rest
+    where (language,_) = parseLanguageFlag args
+          (flags,input,pacOpts) = parseFlags language args
           pacOpts' = nub $ pacOpts ++ reconvertFlags dualFlagMap flags
+                   ++ reconvertFlags pacmanFlagMap flags
 
 -- | Set the local environment.
 prepSettings :: (UserInput,Maybe Language) -> IO (UserInput,Settings)


### PR DESCRIPTION
Now the options parser recognises options
like --arch or --config and passes them
to pacman along with their arguments.

I also had to gut some of the
parseLanguageFlag code which was
messing up other options before I even
could get my hands on them.