### PR TITLE
Fix build on GHC 7.10

### DIFF
--- a/src/Aura/Commands/A.hs
+++ b/src/Aura/Commands/A.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- Handles all `-A` operations
 

--- a/src/Aura/Commands/C.hs
+++ b/src/Aura/Commands/C.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- Handles all `-C` operations.
 
 {-

--- a/src/Aura/Commands/L.hs
+++ b/src/Aura/Commands/L.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- Handles all `-L` operations
 
 {-

--- a/src/Aura/Commands/M.hs
+++ b/src/Aura/Commands/M.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {- Handles all `-M` operations for building from the ABS.
 
 * On `-M` suboptions in general *

--- a/src/Aura/Dependencies.hs
+++ b/src/Aura/Dependencies.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- Library for handling package dependencies and version conflicts.
 
 {-

--- a/src/Aura/Packages/ABS.hs
+++ b/src/Aura/Packages/ABS.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- Handles all ABS related functions.
 
 {-

--- a/src/Aura/Time.hs
+++ b/src/Aura/Time.hs
@@ -29,7 +29,7 @@ module Aura.Time
 import Control.Applicative ((<$>))
 import Text.Printf         (printf)
 import Data.List           (intercalate)
-import Data.Time
+import Data.Time hiding (months)
 
 ---
 


### PR DESCRIPTION
GHC 7.10 is more picky about that inferred types are actually allowed under the current set of extensions, so FlexibleContexts is needed in a few places. Also, Data.Time now exports a months function.