### PR TITLE
Add Localized Yes-/No-Prompt

### DIFF
--- a/src/Aura/Languages.hs
+++ b/src/Aura/Languages.hs
@@ -1785,7 +1785,7 @@ yesNoMessage = \case
     _          -> "[Y/n]"
 
 yesRegex :: Language -> String
-yesRegex = \case
+yesRegex = (++"|^$") . \case
     Croatian   -> "[dD][aA]?"
     German     -> "[jJ][aA]?"
     Norwegian  -> "[jJ][aA]?"

--- a/src/Aura/Languages.hs
+++ b/src/Aura/Languages.hs
@@ -1769,3 +1769,27 @@ customizepkg_1 = let customizepkg = bt "customizepkg" in \case
     Russian    -> customizepkg ++ "не установлен."
     Indonesia  -> customizepkg ++ "tidak terinstal."
     _          -> customizepkg ++ "isn't installed."
+    
+-----------------------
+-- Aura/Utils functions
+-----------------------
+
+yesNoMessage :: Language -> String
+yesNoMessage = \case
+    Croatian   -> "[D/n]"
+    German     -> "[J/n]"
+    Norwegian  -> "[J/n]"
+    Italian    -> "[S/n]"
+    Portuguese -> "[S/n]"
+    French     -> "[O/n]"
+    _          -> "[Y/n]"
+
+yesRegex :: Language -> String
+yesRegex = \case
+    Croatian   -> "[dD][aA]?"
+    German     -> "[jJ][aA]?"
+    Norwegian  -> "[jJ][aA]?"
+    Italian    -> "[sS][iI]?"
+    Portuguese -> "[sS]([iI][mM])?"
+    French     -> "[oO]([uU][iI])?"
+    _          -> "[yY]([eE][sS])?"

--- a/src/Aura/Utils.hs
+++ b/src/Aura/Utils.hs
@@ -29,7 +29,7 @@ import System.IO                 (stdout, hFlush)
 import Data.List                 (sortBy,intercalate)
 
 import Aura.Colour.Text
-import Aura.Languages (Language,whitespace)
+import Aura.Languages (Language,whitespace, yesNoMessage, yesRegex)
 import Aura.Monad.Aura
 import Aura.Settings.Base
 import Aura.Utils.Numbers
@@ -73,10 +73,10 @@ scoldAndFail msg = asks langOf >>= failure . putStrA' red . msg
 -- Takes a prompt message and a regex of valid answer patterns.
 yesNoPrompt :: (Language -> String) -> Aura Bool
 yesNoPrompt msg = asks langOf >>= \lang -> do
-  putStrA yellow $ msg lang ++ " [Y/n] "
+  putStrA yellow $ msg lang ++ " " ++ yesNoMessage lang ++ " "
   liftIO $ hFlush stdout
   response <- liftIO getLine
-  return $ response =~ "y|Y|\\B"
+  return $ response =~ yesRegex lang
 
 -- | Doesn't prompt when `--noconfirm` is used.
 optionalPrompt :: (Language -> String) -> Aura Bool


### PR DESCRIPTION
Translations have been taken from the [pacman repository](https://projects.archlinux.org/pacman.git/tree/src/pacman/po).

This also slightly changes behaviour for the English version, since the regex has changed to mimic pacman's behaviour.