### PR TITLE
Fix Language option parsing

### DIFF
--- a/src/Aura/Flags.hs
+++ b/src/Aura/Flags.hs
@@ -360,9 +360,8 @@ makepkgFlags :: [Flag] -> [String]
 makepkgFlags = fishOutFlag [(IgnoreArch,["--ignorearch"])] []
 
 parseLanguageFlag :: [String] -> (Maybe Language,[String])
-parseLanguageFlag args =
-    case getOpt Permute languageOptions args of
-      (langs,nonOpts,_) -> (getLanguage langs, nonOpts)
+parseLanguageFlag args = case getOpt' Permute languageOptions args of
+    (langs,nonOpts,nolangOpts,_) -> (getLanguage langs, nonOpts ++ nolangOpts)
 
 -- I don't like this.
 parseFlags :: Maybe Language -> [String] -> ([Flag],[String],[String])

--- a/src/aura.hs
+++ b/src/aura.hs
@@ -68,8 +68,8 @@ main = getArgs >>= prepSettings . processFlags >>= execute >>= exit
 
 processFlags :: [String] -> (UserInput,Maybe Language)
 processFlags args = ((flags,nub input,pacOpts'),language)
-    where (language,_) = parseLanguageFlag args
-          (flags,input,pacOpts) = parseFlags language args
+    where (language,args') = parseLanguageFlag args
+          (flags,input,pacOpts) = parseFlags language args'
           pacOpts' = nub $ pacOpts ++ reconvertFlags dualFlagMap flags
                    ++ reconvertFlags pacmanFlagMap flags
 


### PR DESCRIPTION
Before, any language option other than --english caused Aura to crash
with an "incompatible options" error message.

This was caused by the language option being handed to the option
parser as an additional flag, causing all case  branches to be dropped
through.

This bug seems to have gone unnoticed, I discovered it while trying to test #342 
