### PR TITLE
Fix style & genericness

### DIFF
--- a/src/Aura/Bash.hs
+++ b/src/Aura/Bash.hs
@@ -42,8 +42,8 @@ namespace :: String -> String -> Aura Namespace
 namespace pn pb = do
   carch <- ((: []) . NoQuote . carchOf) <$> ask
   case namespace' carch pn pb of
-    Left e   -> liftIO (print e) >> failure "PKGBUILD parse failed."
-    Right ns -> return ns
+    Left e   -> liftIO (print e) *> failure "PKGBUILD parse failed."
+    Right ns -> pure ns
 
 namespace' :: [BashString] -> String -> String -> Either ParseError Namespace
 namespace' ca pn pb =

--- a/src/Aura/Cache.hs
+++ b/src/Aura/Cache.hs
@@ -57,13 +57,13 @@ simplePkg :: FilePath -> SimplePkg
 simplePkg = pkgFileNameAndVer
 
 cache :: [FilePath] -> Cache
-cache = M.fromList . map pair
+cache = M.fromList . fmap pair
     where pair p = (simplePkg p, p)
 
 -- This takes the filepath of the package cache as an argument.
 rawCacheContents :: FilePath -> Aura [String]
 rawCacheContents c = filter dots <$> liftIO (ls c)
-    where dots p = p `notElem` [".",".."]
+    where dots p = p `notElem` [".", ".."]
 
 cacheContents :: FilePath -> Aura Cache
 cacheContents c = cache <$> rawCacheContents c
@@ -83,7 +83,7 @@ getFilename :: Cache -> SimplePkg -> Maybe FilePath
 getFilename c p = M.lookup p c
 
 allNames :: Cache -> [String]
-allNames = map fst . M.keys
+allNames = fmap fst . M.keys
 
 allFilenames :: Cache -> [FilePath]
 allFilenames = M.elems

--- a/src/Aura/Colour/Text.hs
+++ b/src/Aura/Colour/Text.hs
@@ -22,6 +22,7 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 module Aura.Colour.Text where
 
 import Data.List.Split (splitOn)
+import Data.Monoid
 
 import Shell (csi)
 
@@ -32,7 +33,7 @@ data Colour = NoColour
             | Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
             | BRed | BGreen | BYellow | BBlue | BMagenta | BCyan | BWhite
             | BForeground
-            deriving (Eq,Enum,Show)
+            deriving (Eq, Enum, Show)
 
 type Colouror = String -> String
 
@@ -40,7 +41,7 @@ noColour :: Colouror
 noColour = colourize NoColour
 
 -- Normal colours
-black,red,green,yellow,blue,magenta,cyan,white :: Colouror
+black, red, green, yellow, blue, magenta, cyan, white :: Colouror
 black   = colourize Black
 red     = colourize Red
 green   = colourize Green
@@ -51,7 +52,7 @@ cyan    = colourize Cyan
 white   = colourize White
 
 -- Bold/intense colours
-bRed,bGreen,bYellow,bBlue,bMagenta,bCyan,bWhite,bForeground :: Colouror
+bRed, bGreen, bYellow, bBlue, bMagenta, bCyan, bWhite, bForeground :: Colouror
 bRed        = colourize BRed
 bGreen      = colourize BGreen
 bYellow     = colourize BYellow
@@ -127,13 +128,13 @@ where `x` is a colour code and `y` is an "attribute". See below.
 
 -}
 escapeCodes :: [String]
-escapeCodes = normalCodes ++ boldCodes ++ bForegroundCode
+escapeCodes = normalCodes <> boldCodes <> bForegroundCode
 
 normalCodes :: [String]
-normalCodes = map (\n -> csi [0,n] "m") [30..37]
+normalCodes = (\n -> csi [0, n] "m") <$> [30..37]
 
 boldCodes :: [String]
-boldCodes = map (\n -> csi [1,n] "m") [31..37]
+boldCodes = (\n -> csi [1, n] "m") <$> [31..37]
 
 bForegroundCode :: [String]
 bForegroundCode = ["\ESC[m\ESC[1m"]
@@ -145,7 +146,7 @@ resetCode = "\ESC[0m"
 resetCodeRegex :: String
 resetCodeRegex = "\ESC\\[0m"
 
-coloursWithCodes :: [(Colour,String)]
+coloursWithCodes :: [(Colour, String)]
 coloursWithCodes = zip colours escapeCodes
 
 colourize :: Colour -> String -> String
@@ -157,6 +158,6 @@ colourize colour msg =
         where insertCodes code' msg' =
                   case splitOn resetCode msg' of
                     []      -> ""  -- Shouldn't happen?
-                    [_]     -> code' ++ msg' ++ resetCode
+                    [_]     -> code' <> msg' <> resetCode
                     [_, ""] -> msg' -- We're done recursing.
-                    (b:as)  -> insertCodes code' (b ++ code' ++ unwords as)
+                    (b:as)  -> insertCodes code' (b <> code' <> unwords as)

--- a/src/Aura/Commands/A.hs
+++ b/src/Aura/Commands/A.hs
@@ -36,9 +36,10 @@ module Aura.Commands.A
 
 import           Control.Monad
 import           Data.Maybe (fromJust)
-import           Data.Monoid
+import           Data.Monoid ((<>))
 import qualified Data.Set as S (member, fromList)
 import qualified Data.Text as T
+import           Data.Foldable (traverse_, fold)
 import           Linux.Arch.Aur
 import           Text.Printf (printf)
 import           Text.Regex.PCRE ((=~))
@@ -66,10 +67,10 @@ import           Utilities (whenM)
 installOptions :: Aura I.InstallOptions
 installOptions = do
     depsRepo <- absDepsRepo
-    return I.InstallOptions { label         = "AUR"
-                            , installLookup = aurLookup
-                            , repository    = depsRepo <> aurRepo
-                            }
+    pure I.InstallOptions { label         = "AUR"
+                          , installLookup = aurLookup
+                          , repository    = depsRepo <> aurRepo
+                          }
 
 install :: [String] -> [String] -> Aura ()
 install pacOpts ps = do
@@ -80,11 +81,11 @@ upgradeAURPkgs :: [String] -> [String] -> Aura ()
 upgradeAURPkgs pacOpts pkgs = ask >>= \ss -> do
   let notIgnored p = splitName p `notElem` ignoredPkgsOf ss
   notify upgradeAURPkgs_1
-  foreignPkgs <- filter (\(n,_) -> notIgnored n) <$> foreignPackages
-  aurInfos    <- aurInfo $ map (T.pack . fst) foreignPkgs
-  let aurPkgs   = filter (\(n,_) -> T.pack n `elem` map aurNameOf aurInfos) foreignPkgs
-      toUpgrade = filter isntMostRecent $ zip aurInfos (map snd aurPkgs)
-  auraFirst <- auraCheck $ map (aurNameOf . fst) toUpgrade
+  foreignPkgs <- filter (\(n, _) -> notIgnored n) <$> foreignPackages
+  aurInfos    <- aurInfo (T.pack . fst <$> foreignPkgs)
+  let aurPkgs   = filter (\(n, _) -> T.pack n `elem` (aurNameOf <$> aurInfos)) foreignPkgs
+      toUpgrade = filter isntMostRecent $ zip aurInfos (snd <$> aurPkgs)
+  auraFirst <- auraCheck (aurNameOf . fst <$> toUpgrade)
   if auraFirst
      then auraUpgrade pacOpts
      else do
@@ -92,25 +93,25 @@ upgradeAURPkgs pacOpts pkgs = ask >>= \ss -> do
        notify upgradeAURPkgs_2
        if null toUpgrade && null devel
           then warn upgradeAURPkgs_3
-          else reportPkgsToUpgrade $ map (T.unpack . prettify) toUpgrade <> devel
-       install pacOpts $ map (T.unpack . aurNameOf . fst) toUpgrade <> pkgs <> devel
-           where prettify (p,v) = aurNameOf p <> " : " <> T.pack v <> " => " <> aurVersionOf p
+          else reportPkgsToUpgrade $ (T.unpack . prettify <$> toUpgrade) <> devel
+       install pacOpts $ (T.unpack . aurNameOf . fst <$> toUpgrade) <> pkgs <> devel
+           where prettify (p, v) = aurNameOf p <> " : " <> T.pack v <> " => " <> aurVersionOf p
 -- TODO: Use `printf` with `prettify` to line up the colons.
 
 auraCheck :: [T.Text] -> Aura Bool
 auraCheck toUpgrade = if "aura" `elem` toUpgrade
                          then optionalPrompt auraCheck_1
-                         else return False
+                         else pure False
 
 auraUpgrade :: [String] -> Aura ()
 auraUpgrade pacOpts = install pacOpts ["aura"]
 
 develPkgCheck :: Aura [String]
 develPkgCheck = ask >>= \ss ->
-  if rebuildDevel ss then develPkgs else return []
+  if rebuildDevel ss then develPkgs else pure []
 
 aurPkgInfo :: [String] -> Aura ()
-aurPkgInfo (map T.pack -> pkgs) = aurInfo pkgs >>= mapM_ displayAurPkgInfo
+aurPkgInfo (fmap T.pack -> pkgs) = aurInfo pkgs >>= traverse_ displayAurPkgInfo
 
 -- By this point, the Package definitely exists, so we can assume its
 -- PKGBUILD exists on the AUR servers as well.
@@ -118,11 +119,11 @@ displayAurPkgInfo :: AurInfo -> Aura ()
 displayAurPkgInfo ai = ask >>= \ss -> do
     let name = T.unpack $ aurNameOf ai
     ns <- fromJust <$> pkgbuild name >>= namespace name . T.unpack
-    liftIO $ putStrLn $ renderAurPkgInfo ss ai ns ++ "\n"
+    liftIO $ putStrLn $ renderAurPkgInfo ss ai ns <> "\n"
 
 renderAurPkgInfo :: Settings -> AurInfo -> Namespace -> String
 renderAurPkgInfo ss ai ns = entrify ss fields entries
-    where fields   = map bForeground . infoFields . langOf $ ss
+    where fields   = fmap bForeground . infoFields . langOf $ ss
           empty x  = case x of [] -> "None"; _ -> x
           entries = [ magenta "aur"
                     , bForeground $ T.unpack $ aurNameOf ai
@@ -139,24 +140,25 @@ renderAurPkgInfo ss ai ns = entrify ss fields entries
                     , T.unpack $ aurDescriptionOf ai ]
 
 aurPkgSearch :: [String] -> Aura ()
-aurPkgSearch [] = return ()
-aurPkgSearch (concat -> regex) = ask >>= \ss -> do
-    db <- S.fromList . map fst <$> foreignPackages
+aurPkgSearch [] = pure ()
+aurPkgSearch (fold -> regex) = ask >>= \ss -> do
+    db <- S.fromList . fmap fst <$> foreignPackages
     let t = case truncationOf ss of  -- Can't this go anywhere else?
               None -> id
               Head n -> take n
               Tail n -> reverse . take n . reverse
-    results <- map (\x -> (x, T.unpack (aurNameOf x) `S.member` db)) . t <$> aurSearch (T.pack regex)
-    mapM_ (liftIO . putStrLn . renderSearch ss regex) results
+    results <- fmap (\x -> (x, T.unpack (aurNameOf x) `S.member` db)) . t
+                 <$> aurSearch (T.pack regex)
+    traverse_ (liftIO . putStrLn . renderSearch ss regex) results
 
 renderSearch :: Settings -> String -> (AurInfo, Bool) -> String
 renderSearch ss r (i, e) = searchResult
     where searchResult = if beQuiet ss then sparseInfo else verboseInfo
           sparseInfo   = T.unpack $ aurNameOf i
-          verboseInfo  = repo ++ n ++ " " ++ v ++ " (" ++ l ++ " / " ++ p ++
-                         ")" ++ (if e then s else "") ++ "\n    " ++ d
-          c cl cs = case cs =~ ("(?i)" ++ r) of
-                      (b,m,a) -> cl b ++ bCyan m ++ cl a
+          verboseInfo  = repo <> n <> " " <> v <> " (" <> l <> " / " <> p <>
+                         ")" <> (if e then s else "") <> "\n    " <> d
+          c cl cs = case cs =~ ("(?i)" <> r) of
+                      (b, m, a) -> cl b <> bCyan m <> cl a
           repo = magenta "aur/"
           n = c bForeground $ T.unpack $ aurNameOf i
           d = c noColour $ T.unpack $ aurDescriptionOf i
@@ -175,16 +177,16 @@ displayPkgDeps ps = do
 downloadTarballs :: [String] -> Aura ()
 downloadTarballs pkgs = do
   currDir <- liftIO pwd
-  mapM_ (downloadTBall currDir) pkgs
+  traverse_ (downloadTBall currDir) pkgs
     where downloadTBall path pkg = whenM (isAurPackage pkg) $ do
               notify $ downloadTarballs_1 pkg
               void . liftIO $ sourceTarball path $ T.pack pkg
 
 displayPkgbuild :: [String] -> Aura ()
-displayPkgbuild = I.displayPkgbuild (mapM (fmap (fmap T.unpack) . pkgbuild))
+displayPkgbuild = I.displayPkgbuild (traverse (fmap (fmap T.unpack) . pkgbuild))
 
-isntMostRecent :: (AurInfo,String) -> Bool
-isntMostRecent (ai,v) = trueVer > currVer
+isntMostRecent :: (AurInfo, String) -> Bool
+isntMostRecent (ai, v) = trueVer > currVer
   where trueVer = version $ T.unpack $ aurVersionOf ai
         currVer = version v
 

--- a/src/Aura/Commands/B.hs
+++ b/src/Aura/Commands/B.hs
@@ -26,8 +26,9 @@ module Aura.Commands.B
 
 import System.FilePath ((</>))
 import Data.Char       (isDigit)
+import Data.Foldable   (traverse_)
 
-import Aura.Utils (scoldAndFail,optionalPrompt)
+import Aura.Utils (scoldAndFail, optionalPrompt)
 import Aura.Core  (warn)
 import Aura.Monad.Aura
 import Aura.Languages
@@ -50,4 +51,4 @@ cleanStates' n = do
      then warn cleanStates_3
      else do
        states <- getStateFiles
-       liftIO . mapM_ rm . map (stateCache </>) . drop n . reverse $ states
+       liftIO . traverse_ rm . fmap (stateCache </>) . drop n . reverse $ states

--- a/src/Aura/Commands/L.hs
+++ b/src/Aura/Commands/L.hs
@@ -69,7 +69,7 @@ renderLogLookUp ss logFile pkg = entrify ss fields entries <> "\n" <> recent
           matches     = searchLines (" " <> pkg <> " \\(") $ lines logFile
           installDate = head matches =~ "\\[[-:0-9 ]+\\]"
           upgrades    = length $ searchLines " upgraded " matches
-          recent      = unlines . fmap (' ':) . takeLast 5 $ matches
+          recent      = unlines . fmap (" " <>) . takeLast 5 $ matches
           takeLast n  = reverse . take n . reverse
           entries     = [ pkg
                         , installDate

--- a/src/Aura/Commands/L.hs
+++ b/src/Aura/Commands/L.hs
@@ -30,6 +30,8 @@ module Aura.Commands.L
 
 import Text.Regex.PCRE ((=~))
 import Data.List       ((\\))
+import Data.Monoid     ((<>))
+import Data.Foldable   (traverse_)
 
 import Aura.Colour.Text (yellow)
 import Aura.Core        (badReport)
@@ -39,7 +41,7 @@ import Aura.Settings.Base
 import Aura.Monad.Aura
 import Aura.Languages
 
-import Utilities (searchLines,readFileUTF8)
+import Utilities (searchLines, readFileUTF8)
 
 ---
 
@@ -50,24 +52,24 @@ viewLogFile logFilePath = shellCmd "less" [logFilePath]
 searchLogFile :: [String] -> Aura ()
 searchLogFile input = ask >>= \ss -> liftIO $ do
   logFile <- lines <$> readFileUTF8 (logFilePathOf ss)
-  mapM_ putStrLn $ searchLines (unwords input) logFile
+  traverse_ putStrLn $ searchLines (unwords input) logFile
 
 logInfoOnPkg :: [String] -> Aura ()
-logInfoOnPkg []   = return ()
+logInfoOnPkg []   = pure ()
 logInfoOnPkg pkgs = ask >>= \ss -> do
   logFile <- liftIO $ readFile (logFilePathOf ss)
-  let inLog p = logFile =~ (" " ++ p ++ " ")
+  let inLog p = logFile =~ (" " <> p <> " ")
       reals   = filter inLog pkgs
   reportNotInLog (pkgs \\ reals)
-  liftIO $ mapM_ (putStrLn . renderLogLookUp ss logFile) reals
+  liftIO $ traverse_ (putStrLn . renderLogLookUp ss logFile) reals
 
 renderLogLookUp :: Settings -> String -> String -> String
-renderLogLookUp ss logFile pkg = entrify ss fields entries ++ "\n" ++ recent
-    where fields      = map yellow . logLookUpFields . langOf $ ss
-          matches     = searchLines (" " ++ pkg ++ " \\(") $ lines logFile
+renderLogLookUp ss logFile pkg = entrify ss fields entries <> "\n" <> recent
+    where fields      = fmap yellow . logLookUpFields . langOf $ ss
+          matches     = searchLines (" " <> pkg <> " \\(") $ lines logFile
           installDate = head matches =~ "\\[[-:0-9 ]+\\]"
           upgrades    = length $ searchLines " upgraded " matches
-          recent      = unlines . map ((:) ' ') . takeLast 5 $ matches
+          recent      = unlines . fmap (' ':) . takeLast 5 $ matches
           takeLast n  = reverse . take n . reverse
           entries     = [ pkg
                         , installDate

--- a/src/Aura/Commands/O.hs
+++ b/src/Aura/Commands/O.hs
@@ -25,6 +25,9 @@ module Aura.Commands.O
     ( displayOrphans
     , adoptPkg ) where
 
+import Data.Monoid
+import Data.Foldable
+
 import Aura.Core   (orphans, sudo)
 import Aura.Pacman (pacman)
 import Aura.Monad.Aura
@@ -32,8 +35,8 @@ import Aura.Monad.Aura
 ---
 
 displayOrphans :: [String] -> Aura ()
-displayOrphans []   = orphans >>= liftIO . mapM_ putStrLn
+displayOrphans []   = orphans >>= liftIO . traverse_ putStrLn
 displayOrphans pkgs = adoptPkg pkgs
 
 adoptPkg :: [String] -> Aura ()
-adoptPkg pkgs = sudo (pacman $ ["-D","--asexplicit"] ++ pkgs)
+adoptPkg pkgs = sudo (pacman $ ["-D", "--asexplicit"] <> pkgs)

--- a/src/Aura/Conflicts.hs
+++ b/src/Aura/Conflicts.hs
@@ -21,6 +21,7 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Conflicts where
 
+import Data.Monoid ((<>))
 import Data.Foldable (traverse_)
 import Text.Regex.PCRE ((=~))
 
@@ -62,7 +63,7 @@ isVersionConflict :: VersionDemand -> String -> Bool
 isVersionConflict Anything _     = False
 isVersionConflict (LessThan r) c = version c >= version r
 isVersionConflict (MoreThan r) c = version c <= version r
-isVersionConflict (MustBe   r) c = not $ c =~ ('^' : r)
+isVersionConflict (MustBe   r) c = not $ c =~ ("^" <> r)
 isVersionConflict (AtLeast  r) c | version c > version r = False
                                  | isVersionConflict (MustBe r) c = True
                                  | otherwise = False

--- a/src/Aura/Conflicts.hs
+++ b/src/Aura/Conflicts.hs
@@ -21,8 +21,7 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Conflicts where
 
-import Data.Foldable (mapM_)
-import Prelude hiding (mapM_)
+import Data.Foldable (traverse_)
 import Text.Regex.PCRE ((=~))
 
 import Aura.Core
@@ -39,7 +38,7 @@ import Aura.Utils.Numbers (version)
 --    the most recent version?
 
 checkConflicts :: Package -> Dep -> Aura ()
-checkConflicts p d = ask >>= \ss -> mapM_ failure (realPkgConflicts ss p d)
+checkConflicts p d = ask >>= \ss -> traverse_ failure (realPkgConflicts ss p d)
 
 -- | Must be called with a (f)unction that yields the version number
 -- of the most up-to-date form of the package.

--- a/src/Aura/Core.hs
+++ b/src/Aura/Core.hs
@@ -55,10 +55,10 @@ data VersionDemand = LessThan String
                      deriving (Eq)
 
 instance Show VersionDemand where
-    show (LessThan v) = '<' : v
+    show (LessThan v) = "<" <> v
     show (AtLeast v)  = ">=" <> v
-    show (MoreThan v) = '>' : v
-    show (MustBe  v)  = '=' : v
+    show (MoreThan v) = ">" <> v
+    show (MustBe  v)  = "=" <> v
     show Anything     = ""
 
 -- | A package to be installed.
@@ -138,7 +138,7 @@ trueRoot action = ask >>= \ss ->
 -- | A list of non-prebuilt packages installed on the system.
 foreignPackages :: Aura [(String, String)]
 foreignPackages = (fmap fixName . lines) <$> pacmanOutput ["-Qm"]
-    where fixName = hardBreak (== ' ')
+    where fixName = hardBreak (' ' ==)
 
 orphans :: Aura [String]
 orphans = lines <$> pacmanOutput ["-Qqdt"]

--- a/src/Aura/Core.hs
+++ b/src/Aura/Core.hs
@@ -24,6 +24,7 @@ module Aura.Core where
 import Control.Monad    (when)
 import Data.Either      (partitionEithers)
 import Data.List        (isSuffixOf)
+import Data.Monoid
 
 import System.Directory (doesFileExist)
 import Text.Regex.PCRE  ((=~))
@@ -55,7 +56,7 @@ data VersionDemand = LessThan String
 
 instance Show VersionDemand where
     show (LessThan v) = '<' : v
-    show (AtLeast v)  = ">=" ++ v
+    show (AtLeast v)  = ">=" <> v
     show (MoreThan v) = '>' : v
     show (MustBe  v)  = '=' : v
     show Anything     = ""
@@ -90,27 +91,27 @@ newtype Repository = Repository
     { repoLookup :: String -> Aura (Maybe Package) }
 
 instance Monoid Repository where
-    mempty = Repository $ \_ -> return Nothing
+    mempty = Repository $ const (pure Nothing)
 
     a `mappend` b = Repository $ \s -> do
         mpkg <- repoLookup a s
         case mpkg of
             Nothing -> repoLookup b s
-            _       -> return mpkg
+            _       -> pure mpkg
 
 ---------------------------------
 -- Functions common to `Package`s
 ---------------------------------
 -- | Partition a list of packages into pacman and buildable groups.
-partitionPkgs :: [Package] -> ([String],[Buildable])
-partitionPkgs = partitionEithers . map (toEither . pkgInstallTypeOf)
+partitionPkgs :: [Package] -> ([String], [Buildable])
+partitionPkgs = partitionEithers . fmap (toEither . pkgInstallTypeOf)
   where toEither (Pacman s) = Left  s
         toEither (Build  b) = Right b
 
 parseDep :: String -> Dep
 parseDep s = Dep name (getVersionDemand comp ver)
     where patt = "(<|>=|>|=)" :: String
-          (name,comp,ver) = s =~ patt :: (String,String,String)
+          (name, comp, ver) = s =~ patt :: (String, String, String)
           getVersionDemand c v | c == "<"  = LessThan v
                                | c == ">=" = AtLeast v
                                | c == ">"  = MoreThan v
@@ -135,19 +136,19 @@ trueRoot action = ask >>= \ss ->
 
 -- `-Qm` yields a list of sorted values.
 -- | A list of non-prebuilt packages installed on the system.
-foreignPackages :: Aura [(String,String)]
-foreignPackages = (map fixName . lines) <$> pacmanOutput ["-Qm"]
+foreignPackages :: Aura [(String, String)]
+foreignPackages = (fmap fixName . lines) <$> pacmanOutput ["-Qm"]
     where fixName = hardBreak (== ' ')
 
 orphans :: Aura [String]
 orphans = lines <$> pacmanOutput ["-Qqdt"]
 
 develPkgs :: Aura [String]
-develPkgs = (filter isDevelPkg . map fst) <$> foreignPackages
+develPkgs = (filter isDevelPkg . fmap fst) <$> foreignPackages
 
 isDevelPkg :: String -> Bool
 isDevelPkg p = any (`isSuffixOf` p) suffixes
-    where suffixes = ["-git","-hg","-svn","-darcs","-cvs","-bzr"]
+    where suffixes = ["-git", "-hg", "-svn", "-darcs", "-cvs", "-bzr"]
 
 -- This could be:
 -- isIgnored :: String -> Aura Bool
@@ -156,22 +157,22 @@ isIgnored :: String -> [String] -> Bool
 isIgnored pkg toIgnore = pkg `elem` toIgnore
 
 isInstalled :: String -> Aura Bool
-isInstalled pkg = pacmanSuccess ["-Qq",pkg]
+isInstalled pkg = pacmanSuccess ["-Qq", pkg]
 
 removePkgs :: [String] -> [String] -> Aura ()
-removePkgs [] _         = return ()
-removePkgs pkgs pacOpts = pacman  $ ["-Rsu"] ++ pkgs ++ pacOpts
+removePkgs [] _         = pure ()
+removePkgs pkgs pacOpts = pacman  $ ["-Rsu"] <> pkgs <> pacOpts
 
 -- Moving to a libalpm backend will make this less hacked.
 -- | True if a dependency is satisfied by an installed package.
 isSatisfied :: Dep -> Aura Bool
-isSatisfied (Dep name ver) = null <$> pacmanOutput ["-T", name ++ show ver]
+isSatisfied (Dep name ver) = null <$> pacmanOutput ["-T", name <> show ver]
 
 -- | Block further action until the database is free.
 checkDBLock :: Aura ()
 checkDBLock = do
   locked <- liftIO $ doesFileExist lockFile
-  when locked $ warn checkDBLock_1 >> liftIO getLine >> checkDBLock
+  when locked $ warn checkDBLock_1 *> liftIO getLine *> checkDBLock
 
 -------
 -- MISC  -- Too specific for `Utilities.hs` or `Aura.Utils`
@@ -195,5 +196,5 @@ scold :: (Language -> String) -> Aura ()
 scold = colouredMessage red
 
 badReport :: (Language -> String) -> [String] -> Aura ()
-badReport _ []     = return ()
+badReport _ []     = pure ()
 badReport msg pkgs = ask >>= \ss -> printList red cyan (msg $ langOf ss) pkgs

--- a/src/Aura/Diff.hs
+++ b/src/Aura/Diff.hs
@@ -143,8 +143,8 @@ showRange :: LineRange -> String
 showRange r = show (start r) <> "," <> show (rangeLength r)
 
 showBlock :: Block -> [String]
-showBlock b = f . (c :) <$> content b
+showBlock b = f . (c <>) <$> content b
   where (f, c) = case tag b of
-                   F -> (red  , '-')
-                   S -> (green, '+')
-                   B -> (id   , ' ')
+                   F -> (red  , "-")
+                   S -> (green, "+")
+                   B -> (id   , " ")

--- a/src/Aura/Languages.hs
+++ b/src/Aura/Languages.hs
@@ -129,9 +129,9 @@ allLanguages = [English ..]
 bt :: String -> String
 bt cs = "`" <> cyan cs <> "`"
 
-whitespace :: Language -> Char
-whitespace Japanese = '　'  -- \12288
-whitespace _ = ' '          -- \32
+whitespace :: Language -> String
+whitespace Japanese = "　"  -- \12288
+whitespace _ = " "          -- \32
 
 langFromEnv :: String -> Language
 langFromEnv = \case

--- a/src/Aura/Languages.hs
+++ b/src/Aura/Languages.hs
@@ -43,6 +43,7 @@ module Aura.Languages where
 
 import Aura.Colour.Text (cyan, green, red, blue, yellow, magenta, bForeground)
 import qualified Data.Map.Lazy as Map (Map, (!), fromList, toList, mapWithKey)
+import Data.Monoid
 
 ---
 
@@ -60,7 +61,7 @@ data Language = English
               | Serbian
               | Norwegian
               | Indonesia
-                deriving (Eq,Enum,Ord,Read,Show)
+                deriving (Eq, Enum, Ord, Read, Show)
 
 translators :: Map.Map Language String
 translators = Map.fromList
@@ -94,7 +95,7 @@ languageNames = Map.fromList . zip [ Polish, Croatian, Swedish, German, Spanish,
     Serbian    -> [ "Пољски", "Хрватски", "Шведски", "Немачки", "Шпански", "Португалски", "Француски", "Руски", "Италијански", "Српски", "", "Indonesia" ]
     Norwegian  -> [ "Polsk", "Kroatisk", "Svensk", "Tysk", "Spansk", "Portugisisk", "Fransk", "Russisk", "Italiensk", "Serbisk", "Norsk", "Indonesia" ]
     Indonesia  -> [ "Polandia", "Kroasia", "Swedia", "Jerman", "Spanyol", "Portugis", "Prancis", "Rusia", "Italia", "Serbia", "Norwegia", "Indonesia" ]
-    _          -> [ "Polish","Croatian","Swedish","German","Spanish","Portuguese","French","Russian", "Italian", "Serbian", "Norwegian", "Indonesia" ]
+    _          -> [ "Polish", "Croatian", "Swedish", "German", "Spanish", "Portuguese", "French", "Russian", "Italian", "Serbian", "Norwegian", "Indonesia" ]
 
 translatorMsgTitle :: Language -> String
 translatorMsgTitle = \case
@@ -116,16 +117,17 @@ translatorMsgTitle = \case
 translatorMsg :: Language -> [String]
 translatorMsg lang = title : names
   where title = translatorMsgTitle lang
-        names = fmap snd $ Map.toList $ Map.mapWithKey (((.) . (.)) formatLang assocLang) translators
+        names = fmap snd . Map.toList $
+            Map.mapWithKey (\l t -> formatLang (assocLang l t)) translators
         assocLang lang' translator = (translator, languageNames lang Map.! lang')
-        formatLang (translator,lang') = " " ++ translator ++ " (" ++ lang' ++ ")"
+        formatLang (translator, lang') = " " <> translator <> " (" <> lang' <> ")"
 
 allLanguages :: [Language]
 allLanguages = [English ..]
 
 -- Wrap a String in backticks
 bt :: String -> String
-bt cs = "`" ++ cyan cs ++ "`"
+bt cs = "`" <> cyan cs <> "`"
 
 whitespace :: Language -> Char
 whitespace Japanese = '　'  -- \12288
@@ -207,57 +209,57 @@ trueRoot_3 = \case
 
 mustBeRoot_1 :: Language -> String
 mustBeRoot_1 = let sudo = bt "sudo" in \case
-    Japanese   -> sudo ++ "を使わないとそれができない！"
-    Polish     -> "Musisz użyć " ++ sudo ++ ", żeby to zrobić."
-    Croatian   -> "Morate koristiti" ++ sudo ++ "za ovu radnju."
-    Swedish    -> "Du måste använda " ++ sudo ++ " för det."
-    German     -> "Sie müssen dafür " ++ sudo ++ " benutzen."
-    Spanish    -> "Tienes que utilizar " ++ sudo ++ " para eso."
-    Portuguese -> "Utilize " ++ sudo ++ " para isso."
-    French     -> "Vous devez utiliser " ++ sudo ++ " pour ça."
-    Russian    -> "Необходимо использовать " ++ sudo ++ " для этого."
-    Italian    -> "È necessario utilizzare " ++ sudo ++ " per questo."
-    Serbian    -> "Морате да користите " ++ sudo ++ " за ову радњу."
-    Norwegian  -> "Du må bruke " ++ sudo ++ " for det."
-    Indonesia  -> "Anda harus menggunakan " ++ sudo ++ " untuk melakukannya."
-    _          -> "You have to use " ++ sudo ++ " for that."
+    Japanese   -> sudo <> "を使わないとそれができない！"
+    Polish     -> "Musisz użyć " <> sudo <> ", żeby to zrobić."
+    Croatian   -> "Morate koristiti" <> sudo <> "za ovu radnju."
+    Swedish    -> "Du måste använda " <> sudo <> " för det."
+    German     -> "Sie müssen dafür " <> sudo <> " benutzen."
+    Spanish    -> "Tienes que utilizar " <> sudo <> " para eso."
+    Portuguese -> "Utilize " <> sudo <> " para isso."
+    French     -> "Vous devez utiliser " <> sudo <> " pour ça."
+    Russian    -> "Необходимо использовать " <> sudo <> " для этого."
+    Italian    -> "È necessario utilizzare " <> sudo <> " per questo."
+    Serbian    -> "Морате да користите " <> sudo <> " за ову радњу."
+    Norwegian  -> "Du må bruke " <> sudo <> " for det."
+    Indonesia  -> "Anda harus menggunakan " <> sudo <> " untuk melakukannya."
+    _          -> "You have to use " <> sudo <> " for that."
 
 -----------------------
 -- Aura/Build functions
 -----------------------
 buildPackages_1 :: String -> Language -> String
 buildPackages_1 (bt -> p) = \case
-    Japanese   -> p ++ "を作成中・・・"
-    Polish     -> "Budowanie " ++ p ++ "..."
-    Croatian   -> "Gradim " ++ p ++ "..."
-    Swedish    -> "Bygger paket " ++ p ++ "..."
-    German     -> "Baue Paket " ++ p ++ "..."
-    Spanish    -> "Construyendo " ++ p ++ "..."
-    Portuguese -> "Compilando " ++ p ++ "..."
-    French     -> "Compilation de " ++ p ++ "..."
-    Russian    -> "Сборка " ++ p ++ "..."
-    Italian    -> "Compilazione di " ++ p ++ "..."
-    Serbian    -> "Градим " ++ p ++ "..."
-    Norwegian  -> "Bygger " ++ p ++ "..."
-    Indonesia  -> "Membangun " ++ p ++ "..."
-    _          -> "Building " ++ p ++ "..."
+    Japanese   -> p <> "を作成中・・・"
+    Polish     -> "Budowanie " <> p <> "..."
+    Croatian   -> "Gradim " <> p <> "..."
+    Swedish    -> "Bygger paket " <> p <> "..."
+    German     -> "Baue Paket " <> p <> "..."
+    Spanish    -> "Construyendo " <> p <> "..."
+    Portuguese -> "Compilando " <> p <> "..."
+    French     -> "Compilation de " <> p <> "..."
+    Russian    -> "Сборка " <> p <> "..."
+    Italian    -> "Compilazione di " <> p <> "..."
+    Serbian    -> "Градим " <> p <> "..."
+    Norwegian  -> "Bygger " <> p <> "..."
+    Indonesia  -> "Membangun " <> p <> "..."
+    _          -> "Building " <> p <> "..."
 
 buildFail_1 :: String -> Language -> String
 buildFail_1 (bt -> p) = \case
-    Japanese   -> p ++ "の作成は失敗したようだ。"
-    Polish     -> "Budowanie " ++ p ++ " zakończyło się niepowodzeniem."
-    Croatian   -> "Izgradnja " ++ p ++ " nije uspjela."
-    Swedish    -> "Det gick inte att bygga paketet " ++ p ++ "."
-    German     -> "Bauen von " ++ p ++ " ist fehlgeschlagen."
-    Spanish    -> "La construcción de " ++ p ++ " ha fallado."
-    Portuguese -> "Falha na compilação do pacote " ++ p ++ "."
-    French     -> "Bon, la compilation de " ++ p ++ " a échouée."
-    Russian    -> "Что ж, сборка " ++ p ++ " не удалась."
-    Italian    -> "La compilazione di " ++ p ++ "è fallita."
-    Serbian    -> "Изградња пакета " ++ p ++ " није успела."
-    Norwegian  -> "Bygging av " ++ p ++ " feilet."
-    Indonesia  -> "Gagal membangun " ++ p
-    _          -> "Well, building " ++ p ++ " failed."
+    Japanese   -> p <> "の作成は失敗したようだ。"
+    Polish     -> "Budowanie " <> p <> " zakończyło się niepowodzeniem."
+    Croatian   -> "Izgradnja " <> p <> " nije uspjela."
+    Swedish    -> "Det gick inte att bygga paketet " <> p <> "."
+    German     -> "Bauen von " <> p <> " ist fehlgeschlagen."
+    Spanish    -> "La construcción de " <> p <> " ha fallado."
+    Portuguese -> "Falha na compilação do pacote " <> p <> "."
+    French     -> "Bon, la compilation de " <> p <> " a échouée."
+    Russian    -> "Что ж, сборка " <> p <> " не удалась."
+    Italian    -> "La compilazione di " <> p <> "è fallita."
+    Serbian    -> "Изградња пакета " <> p <> " није успела."
+    Norwegian  -> "Bygging av " <> p <> " feilet."
+    Indonesia  -> "Gagal membangun " <> p
+    _          -> "Well, building " <> p <> " failed."
 
 buildFail_2 :: Language -> String
 buildFail_2 = \case
@@ -344,12 +346,12 @@ buildFail_6 = \case
 -- NEEDS TRANSLATION
 buildFail_7 :: String -> Language -> String
 buildFail_7 (bt -> p) = \case
-    Japanese   -> p ++ "の作成スクリプトを収得できなかった。"
-    German     -> "Herunterladen der Build-Skripte für " ++ p ++ " fehlgeschlagen."
-    Portuguese -> "Falhou para obter scripts de compilação para " ++ p ++ "." 
-    Indonesia  -> "Gagal mendapatkan skrip untuk " ++ p ++ "."
-    Russian    -> "Не удалось получить сценарии сборки для " ++ p ++ "."
-    _          -> "Failed to obtain build scripts for " ++ p ++ "."
+    Japanese   -> p <> "の作成スクリプトを収得できなかった。"
+    German     -> "Herunterladen der Build-Skripte für " <> p <> " fehlgeschlagen."
+    Portuguese -> "Falhou para obter scripts de compilação para " <> p <> "."
+    Indonesia  -> "Gagal mendapatkan skrip untuk " <> p <> "."
+    Russian    -> "Не удалось получить сценарии сборки для " <> p <> "."
+    _          -> "Failed to obtain build scripts for " <> p <> "."
 
 displayBuildErrors_1 :: Language -> String
 displayBuildErrors_1 = \case
@@ -391,51 +393,51 @@ getDepsToInstall_1 = \case
 
 getRealPkgConflicts_1 :: String -> String -> String -> Language -> String
 getRealPkgConflicts_1 (bt -> p) (bt -> r) (bt -> d) = \case
-    Japanese   -> "パッケージ" ++ p ++ "はバージョン" ++ d ++ "を要するが" ++ "一番最新のバージョンは" ++ r ++ "。"
-    Polish     -> "Zależność " ++ p ++ " powinna być w wersji " ++ d ++ ", ale najnowsza wersja to " ++ r ++ "."
-    Croatian   -> "Zavisnost " ++ p ++ " zahtjeva verziju " ++ d ++ ", a najnovija dostupna verzija je " ++ r ++ "."
-    Swedish    -> "Beroendepaketet " ++ p ++ " kräver version " ++ d ++ " men den senaste versionen är " ++ r ++ "."
-    German     -> "Die Abhängigkeit " ++ p ++ " verlangt Version " ++ d ++ ", aber die neuste Version ist " ++ r ++ "."
-    Spanish    -> "La dependencia " ++ p ++ " duiere la versión " ++ d ++ " pero la versión más reciente es " ++ r ++ "."
-    Portuguese -> "A dependência " ++ p ++ " exige a versão " ++ d ++ " mas a versão mais recente é " ++ r ++ "."
-    French     -> p ++ " est une dépendance nécessitant la version " ++ d ++ ", mais la plus récente est la version " ++ r ++ "."
-    Russian    -> "Зависимость " ++ p ++ " требует версию " ++ d ++ ", однако самой последней версией является " ++ r ++ "."
-    Italian    -> "La dipendenza " ++ p ++ " richiede la versione " ++ d ++ " ma la versione disponibile è " ++ r ++ "."
-    Serbian    -> "Зависност " ++ p ++ " захтева верзију " ++ d ++ ", али најновија верзија је " ++ r ++ "."
-    Norwegian  -> "Avhengigheten " ++ p ++ " krever versjon " ++ d ++", men den nyeste versjonen er " ++ r ++ "."
-    Indonesia  -> "Dependensi " ++ p ++ " meminta versi " ++ d ++ " namun versi paling baru adalah " ++ r ++ "."
-    _          -> "The dependency " ++ p ++ " demands version " ++ d ++ ", but the most recent version is " ++ r ++ "."
+    Japanese   -> "パッケージ" <> p <> "はバージョン" <> d <> "を要するが" <> "一番最新のバージョンは" <> r <> "。"
+    Polish     -> "Zależność " <> p <> " powinna być w wersji " <> d <> ", ale najnowsza wersja to " <> r <> "."
+    Croatian   -> "Zavisnost " <> p <> " zahtjeva verziju " <> d <> ", a najnovija dostupna verzija je " <> r <> "."
+    Swedish    -> "Beroendepaketet " <> p <> " kräver version " <> d <> " men den senaste versionen är " <> r <> "."
+    German     -> "Die Abhängigkeit " <> p <> " verlangt Version " <> d <> ", aber die neuste Version ist " <> r <> "."
+    Spanish    -> "La dependencia " <> p <> " duiere la versión " <> d <> " pero la versión más reciente es " <> r <> "."
+    Portuguese -> "A dependência " <> p <> " exige a versão " <> d <> " mas a versão mais recente é " <> r <> "."
+    French     -> p <> " est une dépendance nécessitant la version " <> d <> ", mais la plus récente est la version " <> r <> "."
+    Russian    -> "Зависимость " <> p <> " требует версию " <> d <> ", однако самой последней версией является " <> r <> "."
+    Italian    -> "La dipendenza " <> p <> " richiede la versione " <> d <> " ma la versione disponibile è " <> r <> "."
+    Serbian    -> "Зависност " <> p <> " захтева верзију " <> d <> ", али најновија верзија је " <> r <> "."
+    Norwegian  -> "Avhengigheten " <> p <> " krever versjon " <> d <>", men den nyeste versjonen er " <> r <> "."
+    Indonesia  -> "Dependensi " <> p <> " meminta versi " <> d <> " namun versi paling baru adalah " <> r <> "."
+    _          -> "The dependency " <> p <> " demands version " <> d <> ", but the most recent version is " <> r <> "."
 
 getRealPkgConflicts_2 :: String -> Language -> String
 getRealPkgConflicts_2 (bt -> p) = \case
-    Japanese   -> p ++ "は無視されるパッケージ！`pacman.conf`を参考に。"
-    Polish     -> p ++ " jest ignorowany! Sprawdź plik `pacman.conf`."
-    Croatian   -> p ++ " je ignoriran paket! Provjerite svoj `pacman.conf`."
-    Swedish    -> p ++ " är ett ignorerat paket! Kolla din `pacman.conf`-fil."
-    German     -> p ++ " ist ein ignoriertes Paket! Siehe /etc/pacman.conf."
-    Spanish    -> "¡" ++ p ++ " es un paquete ignorado! Revisa tu fichero `pacman.conf`."
-    Portuguese -> p ++ " é um pacote ignorado conforme configuração em `pacman.conf`!"
-    French     -> "Le paquet " ++ p ++ " est ignoré. Vous devriez jeter un œil à votre `pacman.conf`."
-    Russian    -> "Пакет " ++ p ++ " игнорируется! Проверьте ваш файл `pacman.conf`."
-    Italian    -> p ++ " è un pacchetto ignorato, controllare `pacman.conf`."
-    Serbian    -> "Пакет " ++ p ++ " је игнорисан! Видите ваш фајл „pacman.conf“."
-    Norwegian  -> p ++ " er en ignorert pakke! Sjekk din `pacman.conf`-fil."
-    Indonesia  -> p ++ " merupakan paket yang diabaikan! Lihat `pacman.conf` anda."
-    _          -> p ++ " is an ignored package! See your `pacman.conf` file."
+    Japanese   -> p <> "は無視されるパッケージ！`pacman.conf`を参考に。"
+    Polish     -> p <> " jest ignorowany! Sprawdź plik `pacman.conf`."
+    Croatian   -> p <> " je ignoriran paket! Provjerite svoj `pacman.conf`."
+    Swedish    -> p <> " är ett ignorerat paket! Kolla din `pacman.conf`-fil."
+    German     -> p <> " ist ein ignoriertes Paket! Siehe /etc/pacman.conf."
+    Spanish    -> "¡" <> p <> " es un paquete ignorado! Revisa tu fichero `pacman.conf`."
+    Portuguese -> p <> " é um pacote ignorado conforme configuração em `pacman.conf`!"
+    French     -> "Le paquet " <> p <> " est ignoré. Vous devriez jeter un œil à votre `pacman.conf`."
+    Russian    -> "Пакет " <> p <> " игнорируется! Проверьте ваш файл `pacman.conf`."
+    Italian    -> p <> " è un pacchetto ignorato, controllare `pacman.conf`."
+    Serbian    -> "Пакет " <> p <> " је игнорисан! Видите ваш фајл „pacman.conf“."
+    Norwegian  -> p <> " er en ignorert pakke! Sjekk din `pacman.conf`-fil."
+    Indonesia  -> p <> " merupakan paket yang diabaikan! Lihat `pacman.conf` anda."
+    _          -> p <> " is an ignored package! See your `pacman.conf` file."
 
 -- NEEDS TRANSLATION
 missingPkg_1 :: String -> Language -> String
 missingPkg_1 (bt -> p) = \case
-    Croatian   -> "Zavisnost  " ++ p ++ " nije pronađena. Pokušajte pronaći paket koji zadovoljava ovu zavisnost."
-    German     -> "Die Abhängigkeit " ++ p ++ " wurde nicht gefunden." -- Second sentence not translated because I'm confused how it should
+    Croatian   -> "Zavisnost  " <> p <> " nije pronađena. Pokušajte pronaći paket koji zadovoljava ovu zavisnost."
+    German     -> "Die Abhängigkeit " <> p <> " wurde nicht gefunden." -- Second sentence not translated because I'm confused how it should
                                                                        -- help anyone, and can't think of a translation for 'may need to'
-    Norwegian  -> "Avhengigheten " ++ p ++ " ble ikke funnet. Du kan søke etter en pakke som tilfredsstiller avhengigheten."
-    Italian    -> "La dipendenza " ++ p ++ " non è stata trovata. Potrebbe essere necessario cercare un pacchetto che possa soddisfarla?"
-    Portuguese -> "A dependência" ++ p ++ " não foi achada. Talvez tenha que buscar um pacote que a satisfaça."
-    French     -> "La dépendance " ++ p ++ " n'a pas pu être trouvée. Il vous faut trouver un paquet pour la satisfaire."
-    Russian    -> "Зависимость " ++ p ++ " не найдена. Возможно, вам нужно поискать пакет, чтобы удовлетворить её."
-    Indonesia  -> "Dependensi " ++ p ++ " tidak dapat ditemukan. Anda mungkin harus menemukan paket tersebut untuk mencukupi kebutuhan."
-    _          -> "The dependency " ++ p ++ " could not be found. You may need to search for a package to satisfy it."
+    Norwegian  -> "Avhengigheten " <> p <> " ble ikke funnet. Du kan søke etter en pakke som tilfredsstiller avhengigheten."
+    Italian    -> "La dipendenza " <> p <> " non è stata trovata. Potrebbe essere necessario cercare un pacchetto che possa soddisfarla?"
+    Portuguese -> "A dependência" <> p <> " não foi achada. Talvez tenha que buscar um pacote que a satisfaça."
+    French     -> "La dépendance " <> p <> " n'a pas pu être trouvée. Il vous faut trouver un paquet pour la satisfaire."
+    Russian    -> "Зависимость " <> p <> " не найдена. Возможно, вам нужно поискать пакет, чтобы удовлетворить её."
+    Indonesia  -> "Dependensi " <> p <> " tidak dapat ditemukan. Anda mungkin harus menemukan paket tersebut untuk mencukupi kebutuhan."
+    _          -> "The dependency " <> p <> " could not be found. You may need to search for a package to satisfy it."
 
 -----------------
 -- aura functions
@@ -595,10 +597,10 @@ install_5 = \case
 -- 2014 December  7 @ 14:45 - NEEDS TRANSLATIONS
 confirmIgnored_1 :: String -> Language -> String
 confirmIgnored_1 (bt -> p) = \case
-    Japanese   -> p ++ "は無視されるはずのパッケージ。それでも続行？"
-    Portuguese -> p ++ " está marcado como Ignored. Instalá-lo mesmo assim?"
-    Russian    -> p ++ " отмечен как игнорируемый. Всё равно установить?"
-    _          -> p ++ " is marked as Ignored. Install anyway?"
+    Japanese   -> p <> "は無視されるはずのパッケージ。それでも続行？"
+    Portuguese -> p <> " está marcado como Ignored. Instalá-lo mesmo assim?"
+    Russian    -> p <> " отмечен как игнорируемый. Всё равно установить?"
+    _          -> p <> " is marked as Ignored. Install anyway?"
 
 -- NEEDS UPDATE TO REFLECT CHANGED ENGLISH
 reportNonPackages_1 :: Language -> String
@@ -664,101 +666,101 @@ reportPkgsToInstall_1 = \case
 -- NEEDS AN UPDATE
 reportPkgsToInstall_2 :: String -> Language -> String
 reportPkgsToInstall_2 l = \case
-    Japanese   -> l ++ "のパッケージ:"
-    Croatian   -> l ++ " Paketi:"
-    German     -> l ++ " Pakete:"
-    Norwegian  -> l ++ " Pakker:"
-    Italian    -> l ++ " Pacchetti:"
-    Portuguese -> l ++ " Pacotes :"
-    French     -> l ++ " Paquets :"
-    Russian    -> l ++ " Пакеты:"
-    Indonesia  -> l ++ " Paket:"
-    _          -> l ++ " Packages:"
+    Japanese   -> l <> "のパッケージ:"
+    Croatian   -> l <> " Paketi:"
+    German     -> l <> " Pakete:"
+    Norwegian  -> l <> " Pakker:"
+    Italian    -> l <> " Pacchetti:"
+    Portuguese -> l <> " Pacotes :"
+    French     -> l <> " Paquets :"
+    Russian    -> l <> " Пакеты:"
+    Indonesia  -> l <> " Paket:"
+    _          -> l <> " Packages:"
 
 {-}
 reportPkgsToInstall_2 :: String -> Language -> String
 reportPkgsToInstall_2 l = \case
-    Japanese   -> l ++ "の従属パッケージ："
-    Polish     -> "Zależności z " ++ l ++ ":"
-    Croatian   -> "Zavisnosti iz " ++ l ++ "-a:"
-    Swedish    -> "Beroenden ifrån " ++ l ++ ":"
-    German     -> "Abhängigkeiten im " ++ l ++ ":"
-    Spanish    -> "Dependencias en " ++ l ++ ":"
-    Portuguese -> "Dependências no " ++ l ++ ":"
-    French     -> "Dépendances " ++ l ++ "\xa0:"
-    Russian    -> "Зависимости из " ++ l ++ ":"
-    Italian    -> "Dipendenze in " ++ l ++ ":"
-    Serbian    -> "Зависности из " ++ l ++ "-а:"
-    Norwegian  -> "Avhengigheter fra " ++ l ++ ":"
-    _          -> l ++ " dependencies:"
+    Japanese   -> l <> "の従属パッケージ："
+    Polish     -> "Zależności z " <> l <> ":"
+    Croatian   -> "Zavisnosti iz " <> l <> "-a:"
+    Swedish    -> "Beroenden ifrån " <> l <> ":"
+    German     -> "Abhängigkeiten im " <> l <> ":"
+    Spanish    -> "Dependencias en " <> l <> ":"
+    Portuguese -> "Dependências no " <> l <> ":"
+    French     -> "Dépendances " <> l <> "\xa0:"
+    Russian    -> "Зависимости из " <> l <> ":"
+    Italian    -> "Dipendenze in " <> l <> ":"
+    Serbian    -> "Зависности из " <> l <> "-а:"
+    Norwegian  -> "Avhengigheter fra " <> l <> ":"
+    _          -> l <> " dependencies:"
 
 reportPkgsToInstall_3 :: String -> Language -> String
 reportPkgsToInstall_3 l = \case
-    Japanese   -> "主な" ++ l ++ "パッケージ："
-    Polish     -> "Główne pakiety z " ++ l ++ ":"
-    Croatian   -> "Glavni " ++ l ++ " paketi:"
-    Swedish    -> "Huvudpaket ifrån " ++ l ++ ":"
-    German     -> "Hauptpaket aus dem " ++ l ++ ":"
-    Spanish    -> "Paquetes principales de " ++ l ++ ":"
-    Portuguese -> "Pacotes principais do " ++ l ++ ":"
-    French     -> "Principaux paquets " ++ l ++ "\xa0:"
-    Russian    -> "Главные пакеты из " ++ l ++ ":"
-    Italian    -> "Pacchetto principale di " ++ l ++ ":"
-    Serbian    -> "Главни пакети из " ++ l ++ "-а:"
-    Norwegian  -> "Hovedpakker fra " ++ l ++ ":"
-    _          -> "Main " ++ l ++ " packages:"
+    Japanese   -> "主な" <> l <> "パッケージ："
+    Polish     -> "Główne pakiety z " <> l <> ":"
+    Croatian   -> "Glavni " <> l <> " paketi:"
+    Swedish    -> "Huvudpaket ifrån " <> l <> ":"
+    German     -> "Hauptpaket aus dem " <> l <> ":"
+    Spanish    -> "Paquetes principales de " <> l <> ":"
+    Portuguese -> "Pacotes principais do " <> l <> ":"
+    French     -> "Principaux paquets " <> l <> "\xa0:"
+    Russian    -> "Главные пакеты из " <> l <> ":"
+    Italian    -> "Pacchetto principale di " <> l <> ":"
+    Serbian    -> "Главни пакети из " <> l <> "-а:"
+    Norwegian  -> "Hovedpakker fra " <> l <> ":"
+    _          -> "Main " <> l <> " packages:"
 -}
 
 -- NEEDS TRANSLATION
 reportPkgbuildDiffs_1 :: String -> Language -> String
 reportPkgbuildDiffs_1 (bt -> p) = \case
-    Japanese   -> p ++ "のPKGBUILDはまだ保存されていない。"
-    Polish     -> p ++ " nie ma jeszcze przechowywanego pliku PKGBUILD."
-    Croatian   -> p ++ " još nema pohranjen PKGBUILD."
-    German     -> p ++ " hat noch keinen gespeicherten PKGBUILD."
-    Spanish    -> p ++ " no tiene PKGBUILD todavía."
-    Portuguese -> p ++ " não possui PKGBUILD."
-    French     -> p ++ " n'a pas encore de PKGBUILD enregistré."
-    Russian    -> "У " ++ p ++ " ещё нет сохраненного PKGBUILD."
-    Italian    -> p ++ " non ci sono PKGBUILD salvati"
-    Serbian    -> p ++ " још нема похрањен PKGBUILD."
-    Norwegian  -> p ++ " har ingen PKGBUILD ennå."
-    Indonesia  -> p ++ " tidak mempunyai PKGBUILD yang tersimpan untuk saat ini."
-    _          -> p ++ " has no stored PKGBUILD yet."
+    Japanese   -> p <> "のPKGBUILDはまだ保存されていない。"
+    Polish     -> p <> " nie ma jeszcze przechowywanego pliku PKGBUILD."
+    Croatian   -> p <> " još nema pohranjen PKGBUILD."
+    German     -> p <> " hat noch keinen gespeicherten PKGBUILD."
+    Spanish    -> p <> " no tiene PKGBUILD todavía."
+    Portuguese -> p <> " não possui PKGBUILD."
+    French     -> p <> " n'a pas encore de PKGBUILD enregistré."
+    Russian    -> "У " <> p <> " ещё нет сохраненного PKGBUILD."
+    Italian    -> p <> " non ci sono PKGBUILD salvati"
+    Serbian    -> p <> " још нема похрањен PKGBUILD."
+    Norwegian  -> p <> " har ingen PKGBUILD ennå."
+    Indonesia  -> p <> " tidak mempunyai PKGBUILD yang tersimpan untuk saat ini."
+    _          -> p <> " has no stored PKGBUILD yet."
 
 -- NEEDS TRANSLATION
 reportPkgbuildDiffs_2 :: String -> Language -> String
 reportPkgbuildDiffs_2 (bt -> p) = \case
-    Japanese   -> p ++ "のPKGBUILDは最新。"
-    Polish     -> "PKGBUILD pakietu " ++ p ++ " jest aktualny."
-    Croatian   -> "PKGBUILD paketa " ++ p ++ " je na najnovijoj verziji."
-    German     -> "PKGBUILD von " ++ p ++ " ist aktuell."
-    Spanish    -> "El PKGBUILD de " ++ p ++ " está actualizado."
-    Portuguese -> "O PKGBUILD de " ++ p ++ "está atualizado."
-    Russian    -> "PKGBUILD " ++ p ++ " является новейшим."
-    French     -> "Le PKGBUILD de " ++ p ++ " est à jour."
-    Italian    -> "Il PKGBUILD di " ++ p ++ " è aggiornato."
-    Serbian    -> "PKGBUILD пакета " ++ p ++ " је ажуран."
-    Norwegian  -> p ++ "'s PKGBUILD er oppdatert."
-    Indonesia  -> "PKGBUILD dari paket " ++ p ++ " sudah mutakhir."
-    _          -> p ++ " PKGBUILD is up to date."
+    Japanese   -> p <> "のPKGBUILDは最新。"
+    Polish     -> "PKGBUILD pakietu " <> p <> " jest aktualny."
+    Croatian   -> "PKGBUILD paketa " <> p <> " je na najnovijoj verziji."
+    German     -> "PKGBUILD von " <> p <> " ist aktuell."
+    Spanish    -> "El PKGBUILD de " <> p <> " está actualizado."
+    Portuguese -> "O PKGBUILD de " <> p <> "está atualizado."
+    Russian    -> "PKGBUILD " <> p <> " является новейшим."
+    French     -> "Le PKGBUILD de " <> p <> " est à jour."
+    Italian    -> "Il PKGBUILD di " <> p <> " è aggiornato."
+    Serbian    -> "PKGBUILD пакета " <> p <> " је ажуран."
+    Norwegian  -> p <> "'s PKGBUILD er oppdatert."
+    Indonesia  -> "PKGBUILD dari paket " <> p <> " sudah mutakhir."
+    _          -> p <> " PKGBUILD is up to date."
 
 -- NEEDS TRANSLATION
 reportPkgbuildDiffs_3 :: String -> Language -> String
 reportPkgbuildDiffs_3 (bt -> p) = \case
-    Japanese   -> p ++ "のPKGBUILD変更報告："
-    Polish     -> "Zmiany w PKGBUILD dla " ++ p ++ ":"
-    Croatian   -> "Promjene u PKGBUILD-u za " ++ p ++ ":"
-    German     -> "PKGBUILD-Änderungen von " ++ p ++ ":"
-    Spanish    -> "Cambios en el PKGBUILD de " ++ p ++ ":"
-    Portuguese -> p ++ " não tem PKGBUILD."
-    Russian    -> "Изменения, вносимые " ++ p ++ " PKGBUILD:"
-    French     -> "Changements du PKGBUILD de " ++ p ++ " :"
-    Italian    -> "Cambiamenti nel PKGBUILD di " ++ p ++":"
-    Serbian    -> "Промене PKGBUILD-a за " ++ p ++ ":"
-    Norwegian  -> p ++ "'s endringer i PKGBUILD:"
-    Indonesia  -> "Perubahan PKGBUILD " ++ p ++ ":"
-    _          -> p ++ " PKGBUILD changes:"
+    Japanese   -> p <> "のPKGBUILD変更報告："
+    Polish     -> "Zmiany w PKGBUILD dla " <> p <> ":"
+    Croatian   -> "Promjene u PKGBUILD-u za " <> p <> ":"
+    German     -> "PKGBUILD-Änderungen von " <> p <> ":"
+    Spanish    -> "Cambios en el PKGBUILD de " <> p <> ":"
+    Portuguese -> p <> " não tem PKGBUILD."
+    Russian    -> "Изменения, вносимые " <> p <> " PKGBUILD:"
+    French     -> "Changements du PKGBUILD de " <> p <> " :"
+    Italian    -> "Cambiamenti nel PKGBUILD di " <> p <>":"
+    Serbian    -> "Промене PKGBUILD-a за " <> p <> ":"
+    Norwegian  -> p <> "'s endringer i PKGBUILD:"
+    Indonesia  -> "Perubahan PKGBUILD " <> p <> ":"
+    _          -> p <> " PKGBUILD changes:"
 
 -- NEEDS TRANSLATION
 reportPkgsToUpgrade_1 :: Language -> String
@@ -849,37 +851,37 @@ upgradeAURPkgs_3 = \case
 
 downloadTarballs_1 :: String -> Language -> String
 downloadTarballs_1 (bt -> p) = \case
-    Japanese   -> p ++ "のソースコードのターボールをダウンロード中・・・"
-    Polish     -> "Pobieranie paczki źródłowej " ++ p ++ "..."
-    Croatian   -> "Preuzimanje izvornog paketa (tarball) " ++ p ++ "..."
-    Swedish    -> "Laddar ner " ++ p ++ " källkodspaket (tarball)..."
-    German     -> "Lade Quelltext (tarball) von " ++ p ++ " herunter..."
-    Spanish    -> "Descargando los fuentes comprimidos (tarball) de " ++ p ++ " ..."
-    Portuguese -> "Baixando os fontes (tarball) de " ++ p ++ " ..."
-    French     -> "Téléchargement de l'archive de " ++ p ++ " en cours…"
-    Russian    -> "Загрузка исходного архива " ++ p ++ "..."
-    Italian    -> "Downlaod del tarball di " ++ p ++ " in corso..."
-    Serbian    -> "Преузимање архиве изворног кода за " ++ p ++ "..."
-    Norwegian  -> "Laster ned " ++ p ++ " kildekodepakken (tarball)..."
-    Indonesia  -> "Mengunduh tarbal untuk paket " ++ p ++ "..."
-    _          -> "Downloading " ++ p ++ " source tarball..."
+    Japanese   -> p <> "のソースコードのターボールをダウンロード中・・・"
+    Polish     -> "Pobieranie paczki źródłowej " <> p <> "..."
+    Croatian   -> "Preuzimanje izvornog paketa (tarball) " <> p <> "..."
+    Swedish    -> "Laddar ner " <> p <> " källkodspaket (tarball)..."
+    German     -> "Lade Quelltext (tarball) von " <> p <> " herunter..."
+    Spanish    -> "Descargando los fuentes comprimidos (tarball) de " <> p <> " ..."
+    Portuguese -> "Baixando os fontes (tarball) de " <> p <> " ..."
+    French     -> "Téléchargement de l'archive de " <> p <> " en cours…"
+    Russian    -> "Загрузка исходного архива " <> p <> "..."
+    Italian    -> "Downlaod del tarball di " <> p <> " in corso..."
+    Serbian    -> "Преузимање архиве изворног кода за " <> p <> "..."
+    Norwegian  -> "Laster ned " <> p <> " kildekodepakken (tarball)..."
+    Indonesia  -> "Mengunduh tarbal untuk paket " <> p <> "..."
+    _          -> "Downloading " <> p <> " source tarball..."
 
 displayPkgbuild_1 :: String -> Language -> String
 displayPkgbuild_1 (bt -> p) = \case
-    Japanese   -> p ++ "は存在しない。"
-    Polish     -> p ++ " nie istnieje."
-    Croatian   -> p ++ " ne postoji."
-    Swedish    -> p ++ " finns inte."
-    German     -> p ++ " existiert nicht."
-    Spanish    -> p ++ " no existe."
-    Portuguese -> p ++ " não existe."
-    French     -> p ++ " n'existe pas."
-    Russian    -> p ++ " не существует."
-    Italian    -> p ++ " inesistente."
-    Serbian    -> p ++ " не постоји."
-    Norwegian  -> p ++ " finnes ikke."
-    Indonesia  -> p ++ " tidak ada."
-    _          -> p ++ " does not exist."
+    Japanese   -> p <> "は存在しない。"
+    Polish     -> p <> " nie istnieje."
+    Croatian   -> p <> " ne postoji."
+    Swedish    -> p <> " finns inte."
+    German     -> p <> " existiert nicht."
+    Spanish    -> p <> " no existe."
+    Portuguese -> p <> " não existe."
+    French     -> p <> " n'existe pas."
+    Russian    -> p <> " не существует."
+    Italian    -> p <> " inesistente."
+    Serbian    -> p <> " не постоји."
+    Norwegian  -> p <> " finnes ikke."
+    Indonesia  -> p <> " tidak ada."
+    _          -> p <> " does not exist."
 
 removeMakeDepsAfter_1 :: Language -> String
 removeMakeDepsAfter_1 = \case
@@ -919,17 +921,17 @@ cleanStates_1 = \case
 -- NEEDS TRANSLATION
 cleanStates_2 :: Int -> Language -> String
 cleanStates_2 (bt . show -> n) = \case
-    Japanese   -> n ++ "個のパッケージ状態記録だけが残される。その他削除？"
-    Croatian   -> n ++ " stanja paketa će biti zadržano. Ukloniti ostatak?"
-    German     -> n ++ " Paketzustände werden behalten. Den Rest entfernen?"
-    Serbian    -> n ++ " стања пакета ће бити сачувано. Уклонити остатак?"
-    Norwegian  -> n ++ " pakketilstander vil bli beholdt. Vil du fjerne resten?"
-    Italian    -> n ++ " lo stato dei pacchetti sarà mantenuto. Rimuovere i rimanenti?"
-    Portuguese -> n ++ " estados de pacotes serão mantidos. Remover o resto?"
-    French     -> n ++ " états des paquets vont être conservés. Supprimer le reste ?"
-    Russian    -> n ++ " -- столько состояний пакетов будут оставлены. Удалить оставшиеся?"
-    Indonesia  -> n ++ " paket akan tetap sama. Hapus yang lainnya?"
-    _          -> n ++ " package states will be kept. Remove the rest?"
+    Japanese   -> n <> "個のパッケージ状態記録だけが残される。その他削除？"
+    Croatian   -> n <> " stanja paketa će biti zadržano. Ukloniti ostatak?"
+    German     -> n <> " Paketzustände werden behalten. Den Rest entfernen?"
+    Serbian    -> n <> " стања пакета ће бити сачувано. Уклонити остатак?"
+    Norwegian  -> n <> " pakketilstander vil bli beholdt. Vil du fjerne resten?"
+    Italian    -> n <> " lo stato dei pacchetti sarà mantenuto. Rimuovere i rimanenti?"
+    Portuguese -> n <> " estados de pacotes serão mantidos. Remover o resto?"
+    French     -> n <> " états des paquets vont être conservés. Supprimer le reste ?"
+    Russian    -> n <> " -- столько состояний пакетов будут оставлены. Удалить оставшиеся?"
+    Indonesia  -> n <> " paket akan tetap sama. Hapus yang lainnya?"
+    _          -> n <> " package states will be kept. Remove the rest?"
 
 -- NEEDS TRANSLATION
 cleanStates_3 :: Language -> String
@@ -951,20 +953,20 @@ cleanStates_3 = \case
 ----------------------------
 getDowngradeChoice_1 :: String -> Language -> String
 getDowngradeChoice_1 (bt -> p) = \case
-    Japanese   -> p ++ "はどのバージョンにする？"
-    Polish     -> "Którą wersję pakietu " ++ p ++ " zainstalować?"
-    Croatian   -> "Koju verziju paketa " ++ p ++ " želite?"
-    Swedish    -> "Vilken version av " ++ p ++ " vill du ha?"
-    German     -> "Welche Version von " ++ p ++ " möchten Sie haben?"
-    Spanish    -> "¿Qué versión de " ++ p ++ " quieres?"
-    Portuguese -> "Qual versão de " ++ p ++ " deseja?"
-    French     -> "Quelle version de " ++ p ++ " voulez-vous ?"
-    Russian    -> "Какую версию " ++ p ++ " вы хотите?"
-    Italian    -> "Quale versione di " ++ p ++ " preferisci?"
-    Serbian    -> "Коју верзију " ++ p ++ "-а желите?"
-    Norwegian  -> "Hvilken versjon av " ++ p ++ " vil du ha?"
-    Indonesia  -> "Versi dari paket " ++ p ++ " mana yang anda inginkan?"
-    _          -> "What version of " ++ p ++ " do you want?"
+    Japanese   -> p <> "はどのバージョンにする？"
+    Polish     -> "Którą wersję pakietu " <> p <> " zainstalować?"
+    Croatian   -> "Koju verziju paketa " <> p <> " želite?"
+    Swedish    -> "Vilken version av " <> p <> " vill du ha?"
+    German     -> "Welche Version von " <> p <> " möchten Sie haben?"
+    Spanish    -> "¿Qué versión de " <> p <> " quieres?"
+    Portuguese -> "Qual versão de " <> p <> " deseja?"
+    French     -> "Quelle version de " <> p <> " voulez-vous ?"
+    Russian    -> "Какую версию " <> p <> " вы хотите?"
+    Italian    -> "Quale versione di " <> p <> " preferisci?"
+    Serbian    -> "Коју верзију " <> p <> "-а желите?"
+    Norwegian  -> "Hvilken versjon av " <> p <> " vil du ha?"
+    Indonesia  -> "Versi dari paket " <> p <> " mana yang anda inginkan?"
+    _          -> "What version of " <> p <> " do you want?"
 
 backupCache_1 :: Language -> String
 backupCache_1 = \case
@@ -1019,37 +1021,37 @@ backupCache_3 = \case
 
 backupCache_4 :: FilePath -> Language -> String
 backupCache_4 (bt -> dir) = \case
-    Japanese   -> "キャッシュのバックアップ先：" ++ dir
-    Polish     -> "Tworzenie kopii zapasowej pamięci podręcznej w " ++ dir
-    Croatian   -> "Stvaram sigurnosnu kopiju u " ++ dir
-    Swedish    -> "Tar backup på cache-filer till " ++ dir
-    German     -> "Sichere Cache in " ++ dir
-    Spanish    -> "Haciendo una copia de seguridad de la caché en " ++ dir
-    Portuguese -> "Backup do cache sendo feito em " ++ dir
-    French     -> "Copie de sauvegarde dans " ++ dir ++ "."
-    Russian    -> "Бэкап создается в директории " ++ dir
-    Italian    -> "Salvataggio della chace in " ++ dir
-    Serbian    -> "Бекапујем кеш у " ++ dir
-    Norwegian  -> "Tar backup på cache til " ++ dir
-    Indonesia  -> "Melakukan `backup` pada direktori " ++ dir
-    _          -> "Backing up cache to " ++ dir
+    Japanese   -> "キャッシュのバックアップ先：" <> dir
+    Polish     -> "Tworzenie kopii zapasowej pamięci podręcznej w " <> dir
+    Croatian   -> "Stvaram sigurnosnu kopiju u " <> dir
+    Swedish    -> "Tar backup på cache-filer till " <> dir
+    German     -> "Sichere Cache in " <> dir
+    Spanish    -> "Haciendo una copia de seguridad de la caché en " <> dir
+    Portuguese -> "Backup do cache sendo feito em " <> dir
+    French     -> "Copie de sauvegarde dans " <> dir <> "."
+    Russian    -> "Бэкап создается в директории " <> dir
+    Italian    -> "Salvataggio della chace in " <> dir
+    Serbian    -> "Бекапујем кеш у " <> dir
+    Norwegian  -> "Tar backup på cache til " <> dir
+    Indonesia  -> "Melakukan `backup` pada direktori " <> dir
+    _          -> "Backing up cache to " <> dir
 
 backupCache_5 :: Int -> Language -> String
 backupCache_5 (bt . show -> n) = \case
-    Japanese   -> "パッケージのファイル数：" ++ n
-    Polish     -> "Pliki będące częścią\xa0kopii zapasowej: " ++ n
-    Croatian   -> "Datoteke koje su dio sigurnosne kopije: " ++ n
-    Swedish    -> "Paket-filer att ta backup på: " ++ n
-    German     -> "Zu sichernde Paketdateien: " ++ n
-    Spanish    -> "Ficheros de paquetes de los que se hará copia de seguridad: " ++ n
-    Portuguese -> "Arquivos de pacotes para backup: " ++ n
-    French     -> "Copie de sauvegarde des fichiers de paquets suivants : " ++ n
-    Russian    -> "Файлы пакета для бэкапа: " ++ n
-    Italian    -> "File del pacchetto da salvare: " ++ n
-    Serbian    -> "Датотеке за бекап: " ++ n
-    Norwegian  -> "Pakker som blir tatt backup på: " ++ n
-    Indonesia  -> "Jumlah paket yang di-`backup`: " ++ n
-    _          -> "Package files to backup: " ++ n
+    Japanese   -> "パッケージのファイル数：" <> n
+    Polish     -> "Pliki będące częścią\xa0kopii zapasowej: " <> n
+    Croatian   -> "Datoteke koje su dio sigurnosne kopije: " <> n
+    Swedish    -> "Paket-filer att ta backup på: " <> n
+    German     -> "Zu sichernde Paketdateien: " <> n
+    Spanish    -> "Ficheros de paquetes de los que se hará copia de seguridad: " <> n
+    Portuguese -> "Arquivos de pacotes para backup: " <> n
+    French     -> "Copie de sauvegarde des fichiers de paquets suivants : " <> n
+    Russian    -> "Файлы пакета для бэкапа: " <> n
+    Italian    -> "File del pacchetto da salvare: " <> n
+    Serbian    -> "Датотеке за бекап: " <> n
+    Norwegian  -> "Pakker som blir tatt backup på: " <> n
+    Indonesia  -> "Jumlah paket yang di-`backup`: " <> n
+    _          -> "Package files to backup: " <> n
 
 backupCache_6 :: Language -> String
 backupCache_6 = \case
@@ -1104,37 +1106,37 @@ backupCache_8 = \case
 
 copyAndNotify_1 :: Int -> Language -> String
 copyAndNotify_1 (cyan . show -> n) = \case
-    Japanese   -> "#[" ++ n ++"]をコピー中・・・"
-    Polish     -> "Kopiowanie #[" ++ n ++ "]"
-    Croatian   -> "Kopiranje #[" ++ n ++ "]"
-    Swedish    -> "Kopierar #[" ++ n ++ "]"
-    German     -> "Kopiere #[" ++ n ++ "]"
-    Spanish    -> "Copiando #[" ++ n ++ "]"
-    Portuguese -> "Copiando #[" ++ n ++ "]"
-    French     -> "Copie de #[" ++ n ++ "]"
-    Russian    -> "Копируется #[" ++ n ++ "]"
-    Italian    -> "Copiando #[" ++n ++ "]"
-    Serbian    -> "Копирам #[" ++ n ++ "]"
-    Norwegian  -> "Kopierer #[" ++ n ++ "]"
-    Indonesia  -> "Menyalin #[" ++ n ++ "]"
-    _          -> "Copying #[" ++ n ++ "]"
+    Japanese   -> "#[" <> n <>"]をコピー中・・・"
+    Polish     -> "Kopiowanie #[" <> n <> "]"
+    Croatian   -> "Kopiranje #[" <> n <> "]"
+    Swedish    -> "Kopierar #[" <> n <> "]"
+    German     -> "Kopiere #[" <> n <> "]"
+    Spanish    -> "Copiando #[" <> n <> "]"
+    Portuguese -> "Copiando #[" <> n <> "]"
+    French     -> "Copie de #[" <> n <> "]"
+    Russian    -> "Копируется #[" <> n <> "]"
+    Italian    -> "Copiando #[" <>n <> "]"
+    Serbian    -> "Копирам #[" <> n <> "]"
+    Norwegian  -> "Kopierer #[" <> n <> "]"
+    Indonesia  -> "Menyalin #[" <> n <> "]"
+    _          -> "Copying #[" <> n <> "]"
 
 preCleanCache_1 :: String -> Language -> String
 preCleanCache_1 n = \case
-    Japanese   -> n ++ "は数字はない。"
-    Polish     -> n ++ " nie jest liczbą."
-    Croatian   -> n ++ " nije broj. "
-    Swedish    -> n ++ " är inte ett nummer."
-    German     -> n ++ " ist keine Nummer."
-    Spanish    -> n ++ " no es un número."
-    Portuguese -> n ++ " não é um número."
-    French     -> n ++ " n'est pas un nombre."
-    Russian    -> n ++ " не является числом."
-    Italian    -> n ++ " non è un numero."
-    Serbian    -> n ++ " није број."
-    Norwegian  -> n ++ " er ikke et nummer."
-    Indonesia  -> n ++ " bukan angka, coy!"
-    _          -> n ++ " is not a number."
+    Japanese   -> n <> "は数字はない。"
+    Polish     -> n <> " nie jest liczbą."
+    Croatian   -> n <> " nije broj. "
+    Swedish    -> n <> " är inte ett nummer."
+    German     -> n <> " ist keine Nummer."
+    Spanish    -> n <> " no es un número."
+    Portuguese -> n <> " não é um número."
+    French     -> n <> " n'est pas un nombre."
+    Russian    -> n <> " не является числом."
+    Italian    -> n <> " non è un numero."
+    Serbian    -> n <> " није број."
+    Norwegian  -> n <> " er ikke et nummer."
+    Indonesia  -> n <> " bukan angka, coy!"
+    _          -> n <> " is not a number."
 
 cleanCache_1 :: Language -> String
 cleanCache_1 = \case
@@ -1172,20 +1174,20 @@ cleanCache_2 = \case
 
 cleanCache_3 :: Int -> Language -> String
 cleanCache_3 (bt . show -> n) = \case
-    Japanese   -> "パッケージ・ファイルは" ++ n ++ "個保存される。"
-    Polish     -> n ++ " wersji każdego pakietu zostanie zachowane."
-    Croatian   -> n ++ " zadnjih verzija svakog paketa će biti zadržano."
-    Swedish    -> n ++ " av varje paketfil kommer att sparas."
-    German     -> n ++ " jeder Paketdatei wird behalten."
-    Spanish    -> n ++ " ficheros de cada paquete se mantendrán."
-    Portuguese -> n ++ " arquivos de cada pacote serão mantidos."
-    French     -> n ++ " fichiers de chaque paquet sera conservé."
-    Russian    -> n ++ " версии каждого пакета будут нетронуты."
-    Italian    -> n ++ " di ciascun pacchetto sarà mantenuto."
-    Serbian    -> n ++ " верзије сваког од пакета ће бити сачуване."
-    Norwegian  -> n ++ " av hver pakkefil blir beholdt."
-    Indonesia  -> n ++ " berkas dari tiap paket akan disimpan."
-    _          -> n ++ " of each package file will be kept."
+    Japanese   -> "パッケージ・ファイルは" <> n <> "個保存される。"
+    Polish     -> n <> " wersji każdego pakietu zostanie zachowane."
+    Croatian   -> n <> " zadnjih verzija svakog paketa će biti zadržano."
+    Swedish    -> n <> " av varje paketfil kommer att sparas."
+    German     -> n <> " jeder Paketdatei wird behalten."
+    Spanish    -> n <> " ficheros de cada paquete se mantendrán."
+    Portuguese -> n <> " arquivos de cada pacote serão mantidos."
+    French     -> n <> " fichiers de chaque paquet sera conservé."
+    Russian    -> n <> " версии каждого пакета будут нетронуты."
+    Italian    -> n <> " di ciascun pacchetto sarà mantenuto."
+    Serbian    -> n <> " верзије сваког од пакета ће бити сачуване."
+    Norwegian  -> n <> " av hver pakkefil blir beholdt."
+    Indonesia  -> n <> " berkas dari tiap paket akan disimpan."
+    _          -> n <> " of each package file will be kept."
 
 cleanCache_4 :: Language -> String
 cleanCache_4 = \case
@@ -1255,36 +1257,36 @@ cleanNotSaved_1 = \case
 -- NEEDS TRANSLATION
 cleanNotSaved_2 :: Int -> Language -> String
 cleanNotSaved_2 (cyan . show -> s) = \case
-    Japanese   -> "「" ++ s ++ "」の不要パッケージファイルあり。削除？"
-    Croatian   -> s ++ " nepotrebnih datoteka pronađeno. Obrisati?"
-    German     -> s ++ " nicht benötigte Paketdateien gefunden. Löschen?"
-    Norwegian  -> s ++ " unødige pakkefiler funnet. Vil du slette?"
-    Italian    -> s ++ " pacchetti non necessari trovati. Cancellarli?"
-    Portuguese -> s ++ " pacotes não necessários encontrados. Removê-los?"
-    French     -> s ++ " paquets inutiles trouvés. Les supprimer ?"
-    Russian    -> s ++ " -- столько ненужных пакетных файлов обнаружено. Удалить?"
-    Indonesia  -> s ++ " berkas paket yang tidak dibutuhkan ditemukan. Hapus?"
-    _          -> s ++ " unneeded package files found. Delete?"
+    Japanese   -> "「" <> s <> "」の不要パッケージファイルあり。削除？"
+    Croatian   -> s <> " nepotrebnih datoteka pronađeno. Obrisati?"
+    German     -> s <> " nicht benötigte Paketdateien gefunden. Löschen?"
+    Norwegian  -> s <> " unødige pakkefiler funnet. Vil du slette?"
+    Italian    -> s <> " pacchetti non necessari trovati. Cancellarli?"
+    Portuguese -> s <> " pacotes não necessários encontrados. Removê-los?"
+    French     -> s <> " paquets inutiles trouvés. Les supprimer ?"
+    Russian    -> s <> " -- столько ненужных пакетных файлов обнаружено. Удалить?"
+    Indonesia  -> s <> " berkas paket yang tidak dibutuhkan ditemukan. Hapus?"
+    _          -> s <> " unneeded package files found. Delete?"
 
 ----------------------------
 -- Aura/Commands/L functions
 ----------------------------
 logLookUpFields :: Language -> [String]
 logLookUpFields = \case
-    Japanese   -> [ "パッケージ","初インストール","アップグレード回数","近況" ]
-    Polish     -> [ "Pakiet","Pierwsza instalacja","Aktualizacje","Ostatnie akcje" ]
-    Croatian   -> [ "Paket","Prva instalacija","Nadogradnje","Nedavne radnje" ]
-    Swedish    -> [ "Paket","Första installation","Uppgraderingar","Nyliga händelser" ]
-    German     -> [ "Paket","Erste Installation","Aktualisierungen","Letzte Aktionen" ]
-    Spanish    -> [ "Paquete","Primera instalación","Actualizaciones","Acciones Recientes" ]
-    Portuguese -> [ "Pacote","Primeira instalação","Atualizações","Ações Recentes" ]
-    French     -> [ "Paquet","Première installation","Mises à jours","Actions récentes" ]
-    Russian    -> [ "Пакет","Первая установка","Обновления","Недавние действия" ]
-    Italian    -> [ "Package","Prima installazione","Upgrades","Azioni recenti" ]
-    Serbian    -> [ "Пакет","Прва инсталација","Ажурирања","Недавне радње" ]
-    Norwegian  -> [ "Pakke","Første installasjon","Oppgraderinger","Nylige hendelser" ]
+    Japanese   -> [ "パッケージ", "初インストール", "アップグレード回数", "近況" ]
+    Polish     -> [ "Pakiet", "Pierwsza instalacja", "Aktualizacje", "Ostatnie akcje" ]
+    Croatian   -> [ "Paket", "Prva instalacija", "Nadogradnje", "Nedavne radnje" ]
+    Swedish    -> [ "Paket", "Första installation", "Uppgraderingar", "Nyliga händelser" ]
+    German     -> [ "Paket", "Erste Installation", "Aktualisierungen", "Letzte Aktionen" ]
+    Spanish    -> [ "Paquete", "Primera instalación", "Actualizaciones", "Acciones Recientes" ]
+    Portuguese -> [ "Pacote", "Primeira instalação", "Atualizações", "Ações Recentes" ]
+    French     -> [ "Paquet", "Première installation", "Mises à jours", "Actions récentes" ]
+    Russian    -> [ "Пакет", "Первая установка", "Обновления", "Недавние действия" ]
+    Italian    -> [ "Package", "Prima installazione", "Upgrades", "Azioni recenti" ]
+    Serbian    -> [ "Пакет", "Прва инсталација", "Ажурирања", "Недавне радње" ]
+    Norwegian  -> [ "Pakke", "Første installasjon", "Oppgraderinger", "Nylige hendelser" ]
     Indonesia  -> [ "Paket", "Versi sistem", "Tingkatkan", "Aksi sekarang" ]
-    _          -> [ "Package","First Install","Upgrades","Recent Actions" ]
+    _          -> [ "Package", "First Install", "Upgrades", "Recent Actions" ]
 
 reportNotInLog_1 :: Language -> String
 reportNotInLog_1 = \case
@@ -1373,98 +1375,98 @@ auraOperTitle = \case
 
 aurSy :: Language -> String
 aurSy = green . \case
-    Japanese   -> "[A]URに関連する処理\n" ++ "デフォルトでAURからインストール"
-    Polish     -> "Wykonuje akcje związane z [A]UR.\n" ++ "Domyślnie instaluje pakiety z AUR."
-    Croatian   -> "Izvršava radnje s [A]UR-om.\n" ++ "Uobičajena (default) radnja je instaliranje paketa iz AUR-a."
-    Swedish    -> "Utför åtgärder involverandes [A]UR.\n" ++ "Standard-åtgärd installerar ifrån AUR."
-    German     -> "Führe Aktionen aus, die das [A]UR betreffen.\n" ++ "Standardaktion installiert aus dem AUR."
-    Spanish    -> "Realizar acciones relacionadas con el [A]UR.\n" ++ "La acción por defecto es instalar desde AUR."
-    Portuguese -> "Realizar ações envolvendo o [A]UR.\n" ++ "Ação padrão instala do AUR."
-    French     -> "Actions impliquant [A]UR.\n" ++ "Par défaut, installe depuis AUR."
-    Russian    -> "Совершить действия с участием [A]UR.\n" ++ "Действие по умолчанию устанавливает из AUR."
-    Italian    -> "Azioni riguardanti [A]UR.\n" ++ "Di default installa da AUR."
-    Serbian    -> "Извршава радње везане за [A]UR.\n" ++ "Уобичајена радња инсталира из AUR-а."
-    Norwegian  -> "Utfør handlinger som innebærer [A]UR.\n" ++ "Standard-handling installerer fra AUR."
-    Indonesia  -> "Melakukan perbuatan yang berhubungan dengan [A]UR.\n" ++ "Instalasi bawaan dari AUR."
-    _          -> "Perform actions involving the [A]UR.\n" ++ "Default action installs from the AUR."
+    Japanese   -> "[A]URに関連する処理\n" <> "デフォルトでAURからインストール"
+    Polish     -> "Wykonuje akcje związane z [A]UR.\n" <> "Domyślnie instaluje pakiety z AUR."
+    Croatian   -> "Izvršava radnje s [A]UR-om.\n" <> "Uobičajena (default) radnja je instaliranje paketa iz AUR-a."
+    Swedish    -> "Utför åtgärder involverandes [A]UR.\n" <> "Standard-åtgärd installerar ifrån AUR."
+    German     -> "Führe Aktionen aus, die das [A]UR betreffen.\n" <> "Standardaktion installiert aus dem AUR."
+    Spanish    -> "Realizar acciones relacionadas con el [A]UR.\n" <> "La acción por defecto es instalar desde AUR."
+    Portuguese -> "Realizar ações envolvendo o [A]UR.\n" <> "Ação padrão instala do AUR."
+    French     -> "Actions impliquant [A]UR.\n" <> "Par défaut, installe depuis AUR."
+    Russian    -> "Совершить действия с участием [A]UR.\n" <> "Действие по умолчанию устанавливает из AUR."
+    Italian    -> "Azioni riguardanti [A]UR.\n" <> "Di default installa da AUR."
+    Serbian    -> "Извршава радње везане за [A]UR.\n" <> "Уобичајена радња инсталира из AUR-а."
+    Norwegian  -> "Utfør handlinger som innebærer [A]UR.\n" <> "Standard-handling installerer fra AUR."
+    Indonesia  -> "Melakukan perbuatan yang berhubungan dengan [A]UR.\n" <> "Instalasi bawaan dari AUR."
+    _          -> "Perform actions involving the [A]UR.\n" <> "Default action installs from the AUR."
 
 -- NEEDS TRANSLATION
 absSy :: Language -> String
 absSy = magenta . \case
-    Croatian   -> "Izvršava operacije sa ABS stablom.\n" ++ "Uobičajena (default) radnja je ručna izgradnja iz ABS stabla ([M]anual)."
-    German     -> "Führe Aktionen aus, die den ABS-Baum betreffen.\n" ++ "Standardaktion baut [M]anuell aus dem ABS."
-    Norwegian  -> "Utfør handlinger som involverer ABS-treet.\n" ++ "Standard-handling bygger [M]anuelt fra ABS."
-    Portuguese -> "Performa ações envolvendo a árvore ABS.\n" ++ "Ação padrão [M]anualmente compila da ABS."
-    French     -> "Effectue une action impliquant l'arbre ABS.\n" ++ "Par défaut, installe [M]anuellement depuis ABS."
-    Russian    -> "Совершить действия с участием дерева ABS.\n" ++ "Действие по умолчанию выполняет сборку из ABS вручную."
-    Indonesia  -> "Melakukan perbuatan yang berhubungan dengan pohon ABS.\n" ++ "Bawaannya adalah membangun [M]anual dari ABS"
-    _          -> "Perform actions involving the ABS tree.\n" ++ "Default action [M]anually builds from ABS."
+    Croatian   -> "Izvršava operacije sa ABS stablom.\n" <> "Uobičajena (default) radnja je ručna izgradnja iz ABS stabla ([M]anual)."
+    German     -> "Führe Aktionen aus, die den ABS-Baum betreffen.\n" <> "Standardaktion baut [M]anuell aus dem ABS."
+    Norwegian  -> "Utfør handlinger som involverer ABS-treet.\n" <> "Standard-handling bygger [M]anuelt fra ABS."
+    Portuguese -> "Performa ações envolvendo a árvore ABS.\n" <> "Ação padrão [M]anualmente compila da ABS."
+    French     -> "Effectue une action impliquant l'arbre ABS.\n" <> "Par défaut, installe [M]anuellement depuis ABS."
+    Russian    -> "Совершить действия с участием дерева ABS.\n" <> "Действие по умолчанию выполняет сборку из ABS вручную."
+    Indonesia  -> "Melakukan perbuatan yang berhubungan dengan pohon ABS.\n" <> "Bawaannya adalah membangun [M]anual dari ABS"
+    _          -> "Perform actions involving the ABS tree.\n" <> "Default action [M]anually builds from ABS."
 
 -- NEEDS TRANSLATION
 saveS :: Language -> String
 saveS = yellow . \case
-    Japanese   -> "パッケージの設置状態に関する処理\n" ++ "デフォルトでインストール状態を保存する。"
-    Croatian   -> "Upravlja spremanjem i vraćanjem globalnog stanja paketa.\n" ++ "Uobičajena (default) radnja je spremanje trenutnog stanja paketa."
-    German     -> "Verwalte das [S]peichern und Wiederherstellen der globalen Paketzustände.\n" ++ "Standardaktion sichert die Zustände."
-    Serbian    -> "Управља чувањем и враћањем глобалног стања пакета.\n" ++ "Уобичајена радња чува тренутно стање."
-    Norwegian  -> "Administer lagring og gjenoppretting av den globale pakketilstanden.\n" ++ "Standard-handling lagrer denne tilstanden."
-    Portuguese -> "Genrencia o [S]alvamento e restauração do estado global de pacotes" ++ "Por padrão salva o estado atual."
-    Italian    -> "Gestisco il [S]alvataggio e ripristino dello stato globale dei pacchetti.\n" ++ "Salva lo stato in maniera predefinita."
-    French     -> "Gestion de la [S]auvegarde et de la restauration de l'état global des paquets.\n" ++ "Par défaut, sauvegarde l'état actuel."
-    Russian    -> "Настроить [S]охранение и восстановление глобального состояние пакетов.\n" ++ "Действие по умолчанию сохраняет это состояние."
-    Indonesia  -> "Mengatur [S]impan dan pengembalian keadaan paket global.\n" ++ "Perilaku bawaan adalah menyimpan keadaan berikut."
-    _          -> "Manage the [S]aving and restoring of the global package state.\n" ++ "Default action saves this state."
+    Japanese   -> "パッケージの設置状態に関する処理\n" <> "デフォルトでインストール状態を保存する。"
+    Croatian   -> "Upravlja spremanjem i vraćanjem globalnog stanja paketa.\n" <> "Uobičajena (default) radnja je spremanje trenutnog stanja paketa."
+    German     -> "Verwalte das [S]peichern und Wiederherstellen der globalen Paketzustände.\n" <> "Standardaktion sichert die Zustände."
+    Serbian    -> "Управља чувањем и враћањем глобалног стања пакета.\n" <> "Уобичајена радња чува тренутно стање."
+    Norwegian  -> "Administer lagring og gjenoppretting av den globale pakketilstanden.\n" <> "Standard-handling lagrer denne tilstanden."
+    Portuguese -> "Genrencia o [S]alvamento e restauração do estado global de pacotes" <> "Por padrão salva o estado atual."
+    Italian    -> "Gestisco il [S]alvataggio e ripristino dello stato globale dei pacchetti.\n" <> "Salva lo stato in maniera predefinita."
+    French     -> "Gestion de la [S]auvegarde et de la restauration de l'état global des paquets.\n" <> "Par défaut, sauvegarde l'état actuel."
+    Russian    -> "Настроить [S]охранение и восстановление глобального состояние пакетов.\n" <> "Действие по умолчанию сохраняет это состояние."
+    Indonesia  -> "Mengatur [S]impan dan pengembalian keadaan paket global.\n" <> "Perilaku bawaan adalah menyimpan keadaan berikut."
+    _          -> "Manage the [S]aving and restoring of the global package state.\n" <> "Default action saves this state."
 
 downG :: Language -> String
 downG = red . \case
-    Japanese   -> "キャッシュに関連する処理\n" ++ "デフォルトでパッケージをダウングレード"
-    Polish     -> "Wykonuje akcje związane z pamięcią podręczną ([C]ache) pakietów.\n" ++ "Domyślnie instaluje starsze wersje podanych pakietów."
-    Croatian   -> "Izvršava radnje sa [C]ache-om paketa.\n" ++ "Uobičajena (default) radnja je vraćanje paketa na prijašnju verziju."
-    Swedish    -> "Utför åtgärder involverandes paket-[C]ache.\n" ++ "Standard-åtgärd nergraderar valda paket."
-    German     -> "Führe Aktionen aus die den Paket[C]ache betreffen.\n" ++ "Standardaktion downgradet gegebene Pakete."
-    Spanish    -> "Realizar acciones relacionadas con la [C]aché.\n" ++ "La acción por defecto es retornar a versiones antiguas de los paquetes especificados."
-    Portuguese -> "Realiza ações relacionadas ao [C]ache.\n" ++ "Ação padrão retorna os pacotes informados às suas versões anteriores."
-    French     -> "Actions impliquant le [C]ache des paquets.\n" ++ "Par défaut, mets les paquets spécifiés à niveau vers une version antérieure."
-    Russian    -> "Совершить действия с участием кэша пакета ([C]ache).\n" ++ "Действие по умолчанию откатывает данные пакеты к старым версиям."
-    Italian    -> "Azioni riguardanti la [C]ache dei pacchetti.\n" ++ "Di default retrocede il pacchetti."
-    Serbian    -> "Извршава радње везане за кеш пакета.\n" ++ "Уобичајена радња враћа претходну верзију датих пакета."
-    Norwegian  -> "Utfør handlinger som involverer pakke-[C]achen.\n" ++ "Standard-handling nedgraderer den valgte pakken."
-    Indonesia  -> "Melakukan hal yang berhubugnan dengan [C]ache paket.\n" ++ "Perilaku bawaan adalah menurunkan versi dari paket yang diberikan."
-    _          -> "Perform actions involving the package [C]ache.\n" ++ "Default action downgrades given packages."
+    Japanese   -> "キャッシュに関連する処理\n" <> "デフォルトでパッケージをダウングレード"
+    Polish     -> "Wykonuje akcje związane z pamięcią podręczną ([C]ache) pakietów.\n" <> "Domyślnie instaluje starsze wersje podanych pakietów."
+    Croatian   -> "Izvršava radnje sa [C]ache-om paketa.\n" <> "Uobičajena (default) radnja je vraćanje paketa na prijašnju verziju."
+    Swedish    -> "Utför åtgärder involverandes paket-[C]ache.\n" <> "Standard-åtgärd nergraderar valda paket."
+    German     -> "Führe Aktionen aus die den Paket[C]ache betreffen.\n" <> "Standardaktion downgradet gegebene Pakete."
+    Spanish    -> "Realizar acciones relacionadas con la [C]aché.\n" <> "La acción por defecto es retornar a versiones antiguas de los paquetes especificados."
+    Portuguese -> "Realiza ações relacionadas ao [C]ache.\n" <> "Ação padrão retorna os pacotes informados às suas versões anteriores."
+    French     -> "Actions impliquant le [C]ache des paquets.\n" <> "Par défaut, mets les paquets spécifiés à niveau vers une version antérieure."
+    Russian    -> "Совершить действия с участием кэша пакета ([C]ache).\n" <> "Действие по умолчанию откатывает данные пакеты к старым версиям."
+    Italian    -> "Azioni riguardanti la [C]ache dei pacchetti.\n" <> "Di default retrocede il pacchetti."
+    Serbian    -> "Извршава радње везане за кеш пакета.\n" <> "Уобичајена радња враћа претходну верзију датих пакета."
+    Norwegian  -> "Utfør handlinger som involverer pakke-[C]achen.\n" <> "Standard-handling nedgraderer den valgte pakken."
+    Indonesia  -> "Melakukan hal yang berhubugnan dengan [C]ache paket.\n" <> "Perilaku bawaan adalah menurunkan versi dari paket yang diberikan."
+    _          -> "Perform actions involving the package [C]ache.\n" <> "Default action downgrades given packages."
 
 viewL :: Language -> String
 viewL = cyan . \case
-    Japanese   -> "[L]ogfileに関連する処理\n" ++ "デフォルトでlogfileを閲覧用に開く"
-    Polish     -> "Wykonuje akcje związane z dziennikiem ([L]ogiem) pacmana.\n" ++ "Domyślnie otwiera log w trybie tylko do odczytu."
-    Croatian   -> "Izvršavanje radnje sa pacman dnevnikom ([L]ogfile).\n" ++ "Uobičajena (default) radnja je ispis dnevnika."
-    Swedish    -> "Utför åtgärder involverandes pacmans [L]ogfil.\n" ++ "Standard-åtgärd öppnar loggen med read-only-attribut."
-    German     -> "Führe Aktionen aus, die die Pacman-[L]ogdatei betreffen.\n" ++ "Standardaktion öffnet den Log (nur Lesen)"
-    Spanish    -> "Realizar acciones relacionadas con el fichero [L]og de pacman.\n" ++ "La acción por defecto es abrir el log en modo sólo lectura."
-    Portuguese -> "Realiza ações relacionadas ao [L]ogfile do Pacman.\n" ++ "Ação padrão abre o arquivo de log apenas para leitura."
-    French     -> "Actions impliquant le fichier de [L]og (journal) de Pacman.\n" ++ "Par défaut, ouvre le journal en lecture seule."
-    Russian    -> "Совершить действия с участием [L]og-файлов pacman.\n" ++ "Действие по умолчанию открывает лог для просмотра в режиме для чтения."
-    Italian    -> "Azioni riguardanti i [L]ogfile di pacman.\n" ++ "Di default visualizza il log in sola lettura."
-    Serbian    -> "Извршава радње везане за pacman-ов дневник.\n" ++ "Уобичајена радња даје преглед дневника."
-    Norwegian  -> "Utfør handlinger som involverer `pacman`'s [L]oggfil.\n" ++ "Standard-handling åpner loggen for skrivebeskyttet lesing."
-    Indonesia  -> "Melakukan hal yang berhubungan dengan berkas [L]og pacman.\n"++"Aksi bawaan adalah membuka log dengan aturan `baca-saja`."
-    _          -> "Perform actions involving the pacman [L]ogfile.\n" ++ "Default action opens the log for read-only viewing."
+    Japanese   -> "[L]ogfileに関連する処理\n" <> "デフォルトでlogfileを閲覧用に開く"
+    Polish     -> "Wykonuje akcje związane z dziennikiem ([L]ogiem) pacmana.\n" <> "Domyślnie otwiera log w trybie tylko do odczytu."
+    Croatian   -> "Izvršavanje radnje sa pacman dnevnikom ([L]ogfile).\n" <> "Uobičajena (default) radnja je ispis dnevnika."
+    Swedish    -> "Utför åtgärder involverandes pacmans [L]ogfil.\n" <> "Standard-åtgärd öppnar loggen med read-only-attribut."
+    German     -> "Führe Aktionen aus, die die Pacman-[L]ogdatei betreffen.\n" <> "Standardaktion öffnet den Log (nur Lesen)"
+    Spanish    -> "Realizar acciones relacionadas con el fichero [L]og de pacman.\n" <> "La acción por defecto es abrir el log en modo sólo lectura."
+    Portuguese -> "Realiza ações relacionadas ao [L]ogfile do Pacman.\n" <> "Ação padrão abre o arquivo de log apenas para leitura."
+    French     -> "Actions impliquant le fichier de [L]og (journal) de Pacman.\n" <> "Par défaut, ouvre le journal en lecture seule."
+    Russian    -> "Совершить действия с участием [L]og-файлов pacman.\n" <> "Действие по умолчанию открывает лог для просмотра в режиме для чтения."
+    Italian    -> "Azioni riguardanti i [L]ogfile di pacman.\n" <> "Di default visualizza il log in sola lettura."
+    Serbian    -> "Извршава радње везане за pacman-ов дневник.\n" <> "Уобичајена радња даје преглед дневника."
+    Norwegian  -> "Utfør handlinger som involverer `pacman`'s [L]oggfil.\n" <> "Standard-handling åpner loggen for skrivebeskyttet lesing."
+    Indonesia  -> "Melakukan hal yang berhubungan dengan berkas [L]og pacman.\n"<>"Aksi bawaan adalah membuka log dengan aturan `baca-saja`."
+    _          -> "Perform actions involving the pacman [L]ogfile.\n" <> "Default action opens the log for read-only viewing."
 
 orpha :: Language -> String
 orpha = blue . \case
-    Japanese   -> "必要とされていない従属パッケージに関する処理\n" ++ "デフォルトでその従属パッケージの名前を出力"
-    Polish     -> "Wykonuje akcje związane z [O]sieroconymi pakietami.\n" ++ "Domyślnie wyświetla wszystkie osierocone pakiety."
-    Croatian   -> "Izvršava radnje s paketima bez roditelja ([O]rphan).\n" ++ "Uobičajena (default) radnja je izlistavanje paketa bez roditelja."
-    Swedish    -> "Utför åtgärder involverandes [O]rphan-paket.\n" ++ "Standard-åtgärd listar alla orphan-paket."
-    German     -> "Führe Aktionen aus, die verwaiste Pakete ([O]rphans) betreffen.\n" ++ "Standardaktion listet alle verwaisten Pakete auf."
-    Spanish    -> "Realizar acciones relacionadas con paquetes huérfanos ([O]rphan).\n" ++ "La acción por defecto es listar todos los paquetes huérfanos."
-    Portuguese -> "Realiza ações com pacotes [O]rfãos.\n" ++ "Ação padrão lista todos os pactes orfãos."
-    French     -> "Actions impliquant les paquets [O]rphelins.\n" ++ "Par défaut, liste l'ensemble des paquets orphelins."
-    Russian    -> "Совершить действия с участием [O]сиротевших пакетов.\n" ++ "Действие по умолчанию перечисляет все осиротевшие пакеты."
-    Italian    -> "Azioni riguardanti i pacchetti [O]rfani.\n" ++ "Di default elenca i pacchetti orfani."
-    Serbian    -> "Извршава радње везане за пакете без родитеља.\n" ++ "Уобичајена радња листа пакете без родитеља."
-    Norwegian  -> "Utfør handlinger som involverer foreldreløse pakker ([O]rphans).\n" ++ "Standard-handling åpner alle foreldreløse pakker."
-    Indonesia  -> "Melakukan hal yang berhubungan dengan paket [O]rphan.\n" ++ "Perilaku bawaan adalah mencetak daftar semua paket orphan."
-    _          -> "Perform actions involving [O]rphan packages.\n" ++ "Default action lists all orphan packages."
+    Japanese   -> "必要とされていない従属パッケージに関する処理\n" <> "デフォルトでその従属パッケージの名前を出力"
+    Polish     -> "Wykonuje akcje związane z [O]sieroconymi pakietami.\n" <> "Domyślnie wyświetla wszystkie osierocone pakiety."
+    Croatian   -> "Izvršava radnje s paketima bez roditelja ([O]rphan).\n" <> "Uobičajena (default) radnja je izlistavanje paketa bez roditelja."
+    Swedish    -> "Utför åtgärder involverandes [O]rphan-paket.\n" <> "Standard-åtgärd listar alla orphan-paket."
+    German     -> "Führe Aktionen aus, die verwaiste Pakete ([O]rphans) betreffen.\n" <> "Standardaktion listet alle verwaisten Pakete auf."
+    Spanish    -> "Realizar acciones relacionadas con paquetes huérfanos ([O]rphan).\n" <> "La acción por defecto es listar todos los paquetes huérfanos."
+    Portuguese -> "Realiza ações com pacotes [O]rfãos.\n" <> "Ação padrão lista todos os pactes orfãos."
+    French     -> "Actions impliquant les paquets [O]rphelins.\n" <> "Par défaut, liste l'ensemble des paquets orphelins."
+    Russian    -> "Совершить действия с участием [O]сиротевших пакетов.\n" <> "Действие по умолчанию перечисляет все осиротевшие пакеты."
+    Italian    -> "Azioni riguardanti i pacchetti [O]rfani.\n" <> "Di default elenca i pacchetti orfani."
+    Serbian    -> "Извршава радње везане за пакете без родитеља.\n" <> "Уобичајена радња листа пакете без родитеља."
+    Norwegian  -> "Utfør handlinger som involverer foreldreløse pakker ([O]rphans).\n" <> "Standard-handling åpner alle foreldreløse pakker."
+    Indonesia  -> "Melakukan hal yang berhubungan dengan paket [O]rphan.\n" <> "Perilaku bawaan adalah mencetak daftar semua paket orphan."
+    _          -> "Perform actions involving [O]rphan packages.\n" <> "Default action lists all orphan packages."
 
 -------------------------------
 -- Aura/AUR functions
@@ -1487,20 +1489,20 @@ getAURPkgInfo_1 = \case
 -- `Maintainer` value NEEDS UPDATING!
 infoFields :: Language -> [String]
 infoFields = \case
-    Japanese   -> [ "リポジトリ","名前","バージョン","パッケージ状態","管理者","プロジェクト","パッケージページ","ライセンス","従属パッケージ","作成時従属パ","投票数","人気","概要" ]
-    Polish     -> [ "Repository","Nazwa","Wersja","Status w AUR","Maintainer","URL Projektu","URL w AUR","Licencja","Depends On","Build Deps","Głosy","Popularity","Opis" ]
-    Croatian   -> [ "Repozitorij","Ime","Verzija","AUR Stanje","Maintainer","URL Projekta","AUR URL","Licenca","Depends On","Build Deps","Glasovi","Popularity","Opis" ]
-    Swedish    -> [ "Repository","Namn","Version","AUR Status","Maintainer","Projekt URL","AUR URL","Licens","Depends On","Build Deps","Röster","Popularity","Beskrivning" ]
-    German     -> [ "Repository","Name","Version","AUR-Status","Maintainer","Projekt-URL","AUR-URL","Lizenz","Hängt ab von","Build-Abhängigkeiten","Stimmen","Popularity","Beschreibung" ]
-    Spanish    -> [ "Repository","Nombre","Versión","Estado en AUR","Maintainer","URL del proyecto","URL en AUR","Licencia","Depends On","Build Deps","Votos","Descripción" ]
-    Portuguese -> [ "Repositório","Nome","Versão","Estado no AUR","Maintainer","URL do projeto","URL no AUR","Licença","Depends On","Build Deps","Votos","Popularity","Descrição" ]
-    French     -> [ "Dépôt","Nom","Version","Statut de AUR","Mainteneur","URL du projet","URL AUR","Licence","Dépends de","Dépendances de compilation","Votes","Popularity","Description" ]
-    Russian    -> [ "Репозиторий","Название","Версия","Статус в AUR","Ответственный","URL проекта","URL в AUR","Лицензия","Зависит от","Зависимости сборки","Голоса","Popularity","Описание" ]
-    Italian    -> [ "Repository","Nome","Versione","Stato in AUR","Maintainer","URL del progetto","URL AUR","Licenza","Depends On","Build Deps","Voti","Popularity","Descrizione" ]
-    Serbian    -> [ "Ризница","Име","Верзија","Статус у AUR-у","Maintainer","Страница пројекта","Страница у AUR-у","Лиценца","Depends On","Build Deps","Гласови","Popularity","Опис" ]
-    Norwegian  -> [ "Depot","Navn","Versjon","AUR Status","Vedlikeholder","Prosjekt-URL","AUR URL","Lisens","Depends On","Build Deps","Stemmer","Popularity","Beskrivelse" ]
-    Indonesia  -> [ "Lumbung", "Nama", "Versi", "Status AUR", "Pemelihara", "URL Proyek", "URL AUR", "Lisensi", "Bergantung pada", "Dependensi bangun", "Suara", "Popularity","Deskripsi" ]
-    _          -> [ "Repository","Name","Version","AUR Status","Maintainer","Project URL","AUR URL","License","Depends On","Build Deps","Votes","Popularity","Description" ]
+    Japanese   -> [ "リポジトリ", "名前", "バージョン", "パッケージ状態", "管理者", "プロジェクト", "パッケージページ", "ライセンス", "従属パッケージ", "作成時従属パ", "投票数", "人気", "概要" ]
+    Polish     -> [ "Repository", "Nazwa", "Wersja", "Status w AUR", "Maintainer", "URL Projektu", "URL w AUR", "Licencja", "Depends On", "Build Deps", "Głosy", "Popularity", "Opis" ]
+    Croatian   -> [ "Repozitorij", "Ime", "Verzija", "AUR Stanje", "Maintainer", "URL Projekta", "AUR URL", "Licenca", "Depends On", "Build Deps", "Glasovi", "Popularity", "Opis" ]
+    Swedish    -> [ "Repository", "Namn", "Version", "AUR Status", "Maintainer", "Projekt URL", "AUR URL", "Licens", "Depends On", "Build Deps", "Röster", "Popularity", "Beskrivning" ]
+    German     -> [ "Repository", "Name", "Version", "AUR-Status", "Maintainer", "Projekt-URL", "AUR-URL", "Lizenz", "Hängt ab von", "Build-Abhängigkeiten", "Stimmen", "Popularity", "Beschreibung" ]
+    Spanish    -> [ "Repository", "Nombre", "Versión", "Estado en AUR", "Maintainer", "URL del proyecto", "URL en AUR", "Licencia", "Depends On", "Build Deps", "Votos", "Descripción" ]
+    Portuguese -> [ "Repositório", "Nome", "Versão", "Estado no AUR", "Maintainer", "URL do projeto", "URL no AUR", "Licença", "Depends On", "Build Deps", "Votos", "Popularity", "Descrição" ]
+    French     -> [ "Dépôt", "Nom", "Version", "Statut de AUR", "Mainteneur", "URL du projet", "URL AUR", "Licence", "Dépends de", "Dépendances de compilation", "Votes", "Popularity", "Description" ]
+    Russian    -> [ "Репозиторий", "Название", "Версия", "Статус в AUR", "Ответственный", "URL проекта", "URL в AUR", "Лицензия", "Зависит от", "Зависимости сборки", "Голоса", "Popularity", "Описание" ]
+    Italian    -> [ "Repository", "Nome", "Versione", "Stato in AUR", "Maintainer", "URL del progetto", "URL AUR", "Licenza", "Depends On", "Build Deps", "Voti", "Popularity", "Descrizione" ]
+    Serbian    -> [ "Ризница", "Име", "Верзија", "Статус у AUR-у", "Maintainer", "Страница пројекта", "Страница у AUR-у", "Лиценца", "Depends On", "Build Deps", "Гласови", "Popularity", "Опис" ]
+    Norwegian  -> [ "Depot", "Navn", "Versjon", "AUR Status", "Vedlikeholder", "Prosjekt-URL", "AUR URL", "Lisens", "Depends On", "Build Deps", "Stemmer", "Popularity", "Beskrivelse" ]
+    Indonesia  -> [ "Lumbung", "Nama", "Versi", "Status AUR", "Pemelihara", "URL Proyek", "URL AUR", "Lisensi", "Bergantung pada", "Dependensi bangun", "Suara", "Popularity", "Deskripsi" ]
+    _          -> [ "Repository", "Name", "Version", "AUR Status", "Maintainer", "Project URL", "AUR URL", "License", "Depends On", "Build Deps", "Votes", "Popularity", "Description" ]
 
 outOfDateMsg :: Maybe Int -> Language -> String
 outOfDateMsg (Just _) = red . \case
@@ -1580,53 +1582,53 @@ absSync_2 = \case
 
 singleSync_1 :: String -> Language -> String
 singleSync_1 (bt -> p) = \case
-    Japanese   -> p ++ "をABS Treeに同期・・・"
-    Croatian   -> "Sinkroniziram " ++ p ++ " u lokalnom stablu..."
-    German     -> "Synchronisiere " ++ p ++ " in den lokalen ABS-Baum..."
-    Norwegian  -> "Synkroniserer " ++ p ++ " til det lokale ABS-treet..."
-    Italian    -> "Sincronizzo " ++ p ++ " nell'albero ABS locale..."
-    Portuguese -> "Sincronizando " ++ p ++ " para a árvore ABS local..."
-    French     -> "Synchronisation de " ++ p ++ " dans l'arbre ABS local…"
-    Russian    -> p ++ " синхронизируется с локальным деревом ABS..."
-    Indonesia  -> "Menyinkronkan paket " ++ p ++ " dengan pohon ABS lokal..."
-    _          -> "Syncing " ++ p ++ " to the local ABS Tree..."
+    Japanese   -> p <> "をABS Treeに同期・・・"
+    Croatian   -> "Sinkroniziram " <> p <> " u lokalnom stablu..."
+    German     -> "Synchronisiere " <> p <> " in den lokalen ABS-Baum..."
+    Norwegian  -> "Synkroniserer " <> p <> " til det lokale ABS-treet..."
+    Italian    -> "Sincronizzo " <> p <> " nell'albero ABS locale..."
+    Portuguese -> "Sincronizando " <> p <> " para a árvore ABS local..."
+    French     -> "Synchronisation de " <> p <> " dans l'arbre ABS local…"
+    Russian    -> p <> " синхронизируется с локальным деревом ABS..."
+    Indonesia  -> "Menyinkronkan paket " <> p <> " dengan pohon ABS lokal..."
+    _          -> "Syncing " <> p <> " to the local ABS Tree..."
 
 absInfoFields :: Language -> [String]
 absInfoFields = \case
-    Croatian   -> [ "Repozitorij","Ime","Verzija","Zavisnosti","Make Zavisnosti","Opis" ]
-    German     -> [ "Repository","Name","Version","Hängt ab von","Make-Abhängigkeiten","Beschreibung"]
-    Norwegian  -> [ "Depot","Navn","Versjon","Er avhengig av","Make Deps","Beskrivelse"]
-    Italian    -> [ "Repository","Nome","Versione","Dipende da","Make Deps","Descrizione" ]
-    Portuguese -> [ "Repositório","Nome","Versão","Dependências","Depenências de compilação","Descrição" ]
-    French     -> [ "Dépôt","Nom","Version","Dépendances","Dépendances de compilation","Description" ]
-    Russian    -> [ "Репозиторий","Название","Версия","Зависит от","Зависимости Make","Описание" ]
+    Croatian   -> [ "Repozitorij", "Ime", "Verzija", "Zavisnosti", "Make Zavisnosti", "Opis" ]
+    German     -> [ "Repository", "Name", "Version", "Hängt ab von", "Make-Abhängigkeiten", "Beschreibung"]
+    Norwegian  -> [ "Depot", "Navn", "Versjon", "Er avhengig av", "Make Deps", "Beskrivelse"]
+    Italian    -> [ "Repository", "Nome", "Versione", "Dipende da", "Make Deps", "Descrizione" ]
+    Portuguese -> [ "Repositório", "Nome", "Versão", "Dependências", "Depenências de compilação", "Descrição" ]
+    French     -> [ "Dépôt", "Nom", "Version", "Dépendances", "Dépendances de compilation", "Description" ]
+    Russian    -> [ "Репозиторий", "Название", "Версия", "Зависит от", "Зависимости Make", "Описание" ]
     Indonesia  -> [ "Lumbung", "Nama", "Versi", "Bergantung pada", "Dependensi bangun", "Deskripsi" ]
-    _          -> [ "Repository","Name","Version","Depends On","Make Deps","Description" ]
+    _          -> [ "Repository", "Name", "Version", "Depends On", "Make Deps", "Description" ]
 
 repository_1 :: String -> Language -> String
 repository_1 p = \case
-    Japanese   -> p ++ "はどのリポジトリにもない。"
-    Croatian   -> p ++ "nije paket u repozitoriju."
-    German     -> p ++ " ist kein Paket in irgendeinem Repository."
-    Norwegian  -> p ++ " er ikke en pakke i noe depot."
-    Italian    -> p ++ " non è un pacchetto di nessun repository."
-    Portuguese -> p ++ " não é um pacote em nenhum do repositório."
-    French     -> p ++ " n'est pas un paquet dans aucun des dépôts."
-    Russian    -> "Пакет " ++ p ++ " не найден ни в одном репозитории."
-    Indonesia  -> p ++ " bukan merupakan paket pada repositori manapun."
-    _          -> p ++ " is not a package in any repository."
+    Japanese   -> p <> "はどのリポジトリにもない。"
+    Croatian   -> p <> "nije paket u repozitoriju."
+    German     -> p <> " ist kein Paket in irgendeinem Repository."
+    Norwegian  -> p <> " er ikke en pakke i noe depot."
+    Italian    -> p <> " non è un pacchetto di nessun repository."
+    Portuguese -> p <> " não é um pacote em nenhum do repositório."
+    French     -> p <> " n'est pas un paquet dans aucun des dépôts."
+    Russian    -> "Пакет " <> p <> " не найден ни в одном репозитории."
+    Indonesia  -> p <> " bukan merupakan paket pada repositori manapun."
+    _          -> p <> " is not a package in any repository."
 
 pkgbuildKeyMissing :: String -> Language -> String
 pkgbuildKeyMissing key = \case
-    Croatian   -> "Nemoguće izvući vrijednost za " ++ key ++ " iz PKGBUILD-a."
-    German     -> "Kann Schlüssel " ++ key ++ " nicht aus PKGBUILD parsen."
-    Norwegian  -> "Forstår ikke " ++ key ++ " fra PKGBUILD."
-    Italian    -> "Inpossibile elaborare la chiave " ++ key ++ " dal PKGBUILD."
-    Portuguese -> "Impossível parsear " ++ key ++ " no PKGBUILD."
-    French     -> "Impossible d'analyser la clef " ++ key ++ " depuis le PKGBUILD."
-    Russian    -> "Не получилось разобрать ключ " ++ key ++ " из PKGBUILD."
-    Indonesia  -> "Tidak dapat menerjemahkan kunci " ++ key ++ " dari PKGBUILD."
-    _          -> "Unable to parse key " ++ key ++ " from PKGBUILD."
+    Croatian   -> "Nemoguće izvući vrijednost za " <> key <> " iz PKGBUILD-a."
+    German     -> "Kann Schlüssel " <> key <> " nicht aus PKGBUILD parsen."
+    Norwegian  -> "Forstår ikke " <> key <> " fra PKGBUILD."
+    Italian    -> "Inpossibile elaborare la chiave " <> key <> " dal PKGBUILD."
+    Portuguese -> "Impossível parsear " <> key <> " no PKGBUILD."
+    French     -> "Impossible d'analyser la clef " <> key <> " depuis le PKGBUILD."
+    Russian    -> "Не получилось разобрать ключ " <> key <> " из PKGBUILD."
+    Indonesia  -> "Tidak dapat menerjemahkan kunci " <> key <> " dari PKGBUILD."
+    _          -> "Unable to parse key " <> key <> " from PKGBUILD."
 
 missingDescription :: Language -> String
 missingDescription = \case
@@ -1694,17 +1696,17 @@ reinstallAndRemove_1 = \case
 -- NEEDS TRANSLATION
 circDep_1 :: String -> Language -> String
 circDep_1 (bt  -> p) = \case
-    Japanese   -> p ++ "と互いに従属している。"
-    Croatian   -> "Ima kružnu zavisnost sa " ++ p ++ "."
-    German     -> "Hat eine zirkuläre Abhängigkeit mit " ++ p ++ "."
-    Serbian    -> "Има кружну зависност са " ++ p ++ "."
-    Norwegian  -> "Har en sirkulær avhengighet med " ++ p ++ "."
-    Italian    -> "E' una dipendenza circolare di " ++ p ++ "."
-    Portuguese -> "Há uma dependência circular em " ++ p ++ "."
-    French     -> "A une dépendance circulaire avec " ++ p ++ "."
-    Russian    -> "Имеет круговую зависимость с " ++ p ++ "."
-    Indonesia  -> "Mempunyai dependensi sirkular dengan " ++ p ++ "."
-    _          -> "Has a circular dependency with " ++ p ++ "."
+    Japanese   -> p <> "と互いに従属している。"
+    Croatian   -> "Ima kružnu zavisnost sa " <> p <> "."
+    German     -> "Hat eine zirkuläre Abhängigkeit mit " <> p <> "."
+    Serbian    -> "Има кружну зависност са " <> p <> "."
+    Norwegian  -> "Har en sirkulær avhengighet med " <> p <> "."
+    Italian    -> "E' una dipendenza circolare di " <> p <> "."
+    Portuguese -> "Há uma dependência circular em " <> p <> "."
+    French     -> "A une dépendance circulaire avec " <> p <> "."
+    Russian    -> "Имеет круговую зависимость с " <> p <> "."
+    Indonesia  -> "Mempunyai dependensi sirkular dengan " <> p <> "."
+    _          -> "Has a circular dependency with " <> p <> "."
 
 -- NEEDS TRANSLATION
 bashisms_1 :: Language -> String
@@ -1744,33 +1746,33 @@ pacmanFailure_1 = \case
 ----------------------------------
 hotEdit_1 :: String -> Language -> String
 hotEdit_1 (bt -> p) = \case
-    Japanese   -> p ++ "のPKGBUILDを編成？"
-    Polish     -> "Czy chcesz edytować PKGBUILD " ++ p ++ "?"
-    Croatian   -> "Želite li izmjeniti PKGBUILD " ++ p ++ "?"
-    Swedish    -> "Vill du ändra PKGBUILD-filen ifrån " ++ p ++ "?"
-    German     -> "Möchten Sie die PKGBUILD-Datei für " ++ p ++ " bearbeiten?"
-    Spanish    -> "¿Te gustaría editar el PKGBUILD de " ++ p ++ "?"
-    Portuguese -> "Desejaria editar o PKGBUILD de " ++ p ++ "?"
-    French     -> "Voulez-vous éditer le PKGBUILD de " ++ p ++ " ?"
-    Russian    -> "Отредактировать PKGBUILD пакета " ++ p ++ "?"
-    Italian    -> "Volete modificare il PKGBUILD di " ++ p ++ "?"
-    Serbian    -> "Желите ли да измените PKGBUILD за " ++ p ++ "?"
-    Norwegian  -> "Vil du endre PKGBUILD for " ++ p ++ "?"
-    Indonesia  -> "Apakah anda ingin menyunting PKGBUILD untuk paket " ++ p ++ "?"
-    _          -> "Would you like to edit the PKGBUILD of " ++ p ++ "?"
+    Japanese   -> p <> "のPKGBUILDを編成？"
+    Polish     -> "Czy chcesz edytować PKGBUILD " <> p <> "?"
+    Croatian   -> "Želite li izmjeniti PKGBUILD " <> p <> "?"
+    Swedish    -> "Vill du ändra PKGBUILD-filen ifrån " <> p <> "?"
+    German     -> "Möchten Sie die PKGBUILD-Datei für " <> p <> " bearbeiten?"
+    Spanish    -> "¿Te gustaría editar el PKGBUILD de " <> p <> "?"
+    Portuguese -> "Desejaria editar o PKGBUILD de " <> p <> "?"
+    French     -> "Voulez-vous éditer le PKGBUILD de " <> p <> " ?"
+    Russian    -> "Отредактировать PKGBUILD пакета " <> p <> "?"
+    Italian    -> "Volete modificare il PKGBUILD di " <> p <> "?"
+    Serbian    -> "Желите ли да измените PKGBUILD за " <> p <> "?"
+    Norwegian  -> "Vil du endre PKGBUILD for " <> p <> "?"
+    Indonesia  -> "Apakah anda ingin menyunting PKGBUILD untuk paket " <> p <> "?"
+    _          -> "Would you like to edit the PKGBUILD of " <> p <> "?"
 
 customizepkg_1 :: Language -> String
 customizepkg_1 = let customizepkg = bt "customizepkg" in \case
-    Japanese   -> customizepkg ++ "はインストールされていない。"
-    Croatian   -> customizepkg ++ "nije instaliran."
-    German     -> customizepkg ++ "ist nicht installiert."
-    Norwegian  -> customizepkg ++ "er ikke installert."
-    Italian    -> customizepkg ++ "non è installato."
-    Portuguese -> customizepkg ++ "não está instalado."
-    French     -> customizepkg ++ "n'est pas installé."
-    Russian    -> customizepkg ++ "не установлен."
-    Indonesia  -> customizepkg ++ "tidak terinstal."
-    _          -> customizepkg ++ "isn't installed."
+    Japanese   -> customizepkg <> "はインストールされていない。"
+    Croatian   -> customizepkg <> "nije instaliran."
+    German     -> customizepkg <> "ist nicht installiert."
+    Norwegian  -> customizepkg <> "er ikke installert."
+    Italian    -> customizepkg <> "non è installato."
+    Portuguese -> customizepkg <> "não está instalado."
+    French     -> customizepkg <> "n'est pas installé."
+    Russian    -> customizepkg <> "не установлен."
+    Indonesia  -> customizepkg <> "tidak terinstal."
+    _          -> customizepkg <> "isn't installed."
     
 -----------------------
 -- Aura/Utils functions
@@ -1787,7 +1789,7 @@ yesNoMessage = \case
     _          -> "[Y/n]"
 
 yesRegex :: Language -> String
-yesRegex = (++"|^$") . \case
+yesRegex = (<> "|^$") . \case
     Croatian   -> "[dD][aA]?"
     German     -> "[jJ][aA]?"
     Norwegian  -> "[jJ][aA]?"

--- a/src/Aura/Monad/Aura.hs
+++ b/src/Aura/Monad/Aura.hs
@@ -40,7 +40,7 @@ import Aura.Settings.Base (Settings)
 ---
 
 {- The Aura Monad. Functions of note:
-return  : yields a successful value.
+pure    : yields a successful value.
 failure : yields an error and bypasses all other operations.
 catch   : catches an error.
 wrap    : If given an Either, rewraps it into an Aura Monad.
@@ -64,4 +64,4 @@ catch a h = catchError a h
 
 wrap :: Either String a -> Aura a
 wrap (Left m)  = failure m
-wrap (Right a) = return a
+wrap (Right a) = pure a

--- a/src/Aura/Packages/ABS.hs
+++ b/src/Aura/Packages/ABS.hs
@@ -88,9 +88,9 @@ makeBuildable :: String -> String -> Aura Buildable
 makeBuildable repo name = do
   pb <- absPkgbuild repo name
   pure Buildable { baseNameOf   = name
-                   , pkgbuildOf   = pb
-                   , isExplicit   = False
-                   , buildScripts = \fp -> Just <$> copyTo repo name fp }
+                 , pkgbuildOf   = pb
+                 , isExplicit   = False
+                 , buildScripts = \fp -> Just <$> copyTo repo name fp }
 
 copyTo :: String -> String -> FilePath -> IO FilePath
 copyTo repo name fp = do

--- a/src/Aura/Packages/ABS.hs
+++ b/src/Aura/Packages/ABS.hs
@@ -44,9 +44,9 @@ module Aura.Packages.ABS
 
 import           Control.Monad
 import           Data.List          (find)
+import           Data.Foldable      (fold)
 import           Data.Set           (Set)
 import qualified Data.Set           as Set
-import qualified Data.Traversable   as Traversable
 import           System.Directory   (doesFileExist, doesDirectoryExist)
 import           System.FilePath    ((</>), takeBaseName)
 import           Text.Regex.PCRE    ((=~))
@@ -69,16 +69,16 @@ import qualified Shell              as Sh (quietShellCmd)
 ---
 
 absLookup :: String -> Aura (Maybe Buildable)
-absLookup name = syncRepo name >>= maybe (return Nothing) makeSynced
+absLookup name = syncRepo name >>= maybe (pure Nothing) makeSynced
   where makeSynced repo = do
             whenM (not <$> synced repo name) $ singleSync repo name
             found <- synced repo name
             if found
                 then Just <$> makeBuildable repo name
-                else return Nothing  -- split package, probably
+                else pure Nothing  -- split package, probably
 
 absRepo :: Repository
-absRepo = Repository $ absLookup >=> Traversable.mapM packageBuildable
+absRepo = Repository $ absLookup >=> traverse packageBuildable
 
 absDepsRepo :: Aura Repository
 absDepsRepo = asks (getRepo . buildABSDeps)
@@ -87,21 +87,21 @@ absDepsRepo = asks (getRepo . buildABSDeps)
 makeBuildable :: String -> String -> Aura Buildable
 makeBuildable repo name = do
   pb <- absPkgbuild repo name
-  return Buildable { baseNameOf   = name
+  pure Buildable { baseNameOf   = name
                    , pkgbuildOf   = pb
                    , isExplicit   = False
                    , buildScripts = \fp -> Just <$> copyTo repo name fp }
 
 copyTo :: String -> String -> FilePath -> IO FilePath
 copyTo repo name fp = do
-    void $ Sh.quietShellCmd "cp" ["-R",loc,fp]
-    return $ fp </> name
+    void $ Sh.quietShellCmd "cp" ["-R", loc, fp]
+    pure $ fp </> name
         where loc = absBasePath </> repo </> name
 
 -------
 -- WORK
 -------
-newtype ABSTree = ABSTree [(String,Set String)]
+newtype ABSTree = ABSTree [(String, Set String)]
 
 absBasePath :: FilePath
 absBasePath = "/var/abs"
@@ -110,11 +110,11 @@ absBasePath = "/var/abs"
 absTree :: Aura ABSTree
 absTree = liftIO $ do
     repos <- ls'' absBasePath >>= filterM doesDirectoryExist
-    ABSTree <$> mapM populate repos
+    ABSTree <$> traverse populate repos
   where
     populate repo = do
         ps <- ls' repo
-        return (takeBaseName repo, Set.fromList ps)
+        pure (takeBaseName repo, Set.fromList ps)
 
 pkgRepo :: ABSTree -> String -> Maybe String
 pkgRepo (ABSTree repos) p = fst <$> find containsPkg repos
@@ -123,9 +123,9 @@ pkgRepo (ABSTree repos) p = fst <$> find containsPkg repos
 
 -- | All packages in the local ABS tree in the form: "repo/package"
 flatABSTree :: ABSTree -> [String]
-flatABSTree (ABSTree repos) = concatMap flat repos
+flatABSTree (ABSTree repos) = foldMap flat repos
   where
-    flat (r, ps) = map (r </>) $ Set.toList ps
+    flat (r, ps) = (r </>) <$> Set.toList ps
 
 absPkgbuildPath :: String -> String -> FilePath
 absPkgbuildPath repo pkg = absBasePath </> repo </> pkg </> "PKGBUILD"
@@ -135,13 +135,13 @@ absPkgbuild repo pkg = liftIO $ readFileUTF8 (absPkgbuildPath repo pkg)
 
 syncRepo :: String -> Aura (Maybe String)
 syncRepo p = do
-  i <- pacmanOutput ["-Si",p]
+  i <- pacmanOutput ["-Si", p]
   case i of
-    "" -> return Nothing
+    "" -> pure Nothing
     _  -> do
       let pat = "Repository[ ]+: "
-          (_,_,repo) = head (lines i) =~ pat :: (String,String,String)
-      return $ Just repo
+          (_, _, repo) = head (lines i) =~ pat :: (String, String, String)
+      pure $ Just repo
 
 synced :: String -> String -> Aura Bool
 synced repo pkg = liftIO . doesFileExist $ absPkgbuildPath repo pkg
@@ -177,22 +177,22 @@ pkgInfo :: String -> String -> Aura PkgInfo
 pkgInfo repo name = do
     pb <- absPkgbuild repo name
     ns <- namespace name pb
-    return PkgInfo
+    pure PkgInfo
         { nameOf        = name
         , repoOf        = repo
         , trueVersionOf = trueVersion ns
         , dependsOf     = value ns "depends"
         , makeDependsOf = value ns "makedepends"
-        , descriptionOf = concat $ value ns "pkgdesc"
+        , descriptionOf = fold $ value ns "pkgdesc"
         }
 
 absInfoLookup :: ABSTree -> String -> Aura (Maybe PkgInfo)
 absInfoLookup tree name =
-    Traversable.mapM (\repo -> pkgInfo repo name) $ pkgRepo tree name
+    traverse (\repo -> pkgInfo repo name) $ pkgRepo tree name
 
 -- | All packages in the local ABS tree which match a given pattern.
 absSearchLookup :: ABSTree -> String -> Aura [PkgInfo]
-absSearchLookup (ABSTree tree) pattern = mapM (uncurry pkgInfo) matches
+absSearchLookup (ABSTree tree) pattern = traverse (uncurry pkgInfo) matches
   where
-    matches       = concatMap match tree
-    match (r, ps) = map (\p -> (r, p)) . filter (=~ pattern) $ Set.toList ps
+    matches       = foldMap match tree
+    match (r, ps) = fmap (\p -> (r, p)) . filter (=~ pattern) $ Set.toList ps

--- a/src/Aura/Packages/AUR.hs
+++ b/src/Aura/Packages/AUR.hs
@@ -38,7 +38,6 @@ import           Data.List            (sortBy)
 import           Data.Monoid          ((<>))
 import           Data.Maybe
 import qualified Data.Text            as T
-import           Data.Traversable     (traverse)
 import           Linux.Arch.Aur
 import           System.FilePath      ((</>))
 

--- a/src/Aura/Pkgbuild/Records.hs
+++ b/src/Aura/Pkgbuild/Records.hs
@@ -25,6 +25,7 @@ module Aura.Pkgbuild.Records where
 
 import System.Directory (doesFileExist)
 import System.FilePath  ((</>))
+import Data.Foldable    (traverse_)
 
 import Aura.Pkgbuild.Base
 import Aura.Monad.Aura
@@ -45,7 +46,7 @@ hasPkgbuildStored :: String -> Aura Bool
 hasPkgbuildStored = liftIO . doesFileExist . pkgbuildPath 
 
 storePkgbuilds :: [Buildable] -> Aura ()
-storePkgbuilds = mapM_ (\p -> writePkgbuild (baseNameOf p) (pkgbuildOf p))
+storePkgbuilds = traverse_ (\p -> writePkgbuild (baseNameOf p) (pkgbuildOf p))
 
 readPkgbuild :: String -> Aura String
 readPkgbuild = liftIO . readFileUTF8 . pkgbuildPath

--- a/src/Aura/Settings/Base.hs
+++ b/src/Aura/Settings/Base.hs
@@ -29,9 +29,9 @@ import Shell (Environment)
 
 ---
 
-data SortScheme = ByVote | Alphabetically deriving (Eq,Show)
+data SortScheme = ByVote | Alphabetically deriving (Eq, Show)
 
-data Truncation = None | Head Int | Tail Int deriving (Eq,Show)
+data Truncation = None | Head Int | Tail Int deriving (Eq, Show)
 
 -- The global settings as set by the user with command-line flags.
 data Settings = Settings { inputOf         :: [String]

--- a/src/Aura/Shell.hs
+++ b/src/Aura/Shell.hs
@@ -45,7 +45,7 @@ quietShellCmd :: String -> [String] -> Aura String
 quietShellCmd cmd args = tripleSnd <$> liftIO (S.quietShellCmd' cmd args)
 
 -- More verbose return type.
-quietShellCmd' :: String -> [String] -> Aura (ExitCode,String,String)
+quietShellCmd' :: String -> [String] -> Aura (ExitCode, String, String)
 quietShellCmd' cmd args = liftIO $ S.quietShellCmd' cmd args
 
 -- Should it report _what_ call failed?
@@ -53,5 +53,5 @@ checkExitCode :: ExitCode -> Aura ()
 checkExitCode = checkExitCode' ""
 
 checkExitCode' :: String -> ExitCode -> Aura ()
-checkExitCode' s ec | S.didProcessSucceed ec = return ()
+checkExitCode' s ec | S.didProcessSucceed ec = pure ()
                     | otherwise              = failure s

--- a/src/Aura/Tests/CoreTest.hs
+++ b/src/Aura/Tests/CoreTest.hs
@@ -7,7 +7,7 @@ import Aura.Core
 test_getDevelPkgs = runAura getDevelPkgs sampleSettings
 
 -- Should produce `Right []`
-test01 = runAura ((map fst `fmap` getForeignPackages) >>= filterRepoPkgs)
+test01 = runAura ((fmap fst <$> getForeignPackages) >>= filterRepoPkgs)
          sampleSettings
 
-test02 = runAura (namespaceOf `fmap` aurPkg "dwarffortress-ironhand") sampleSettings
+test02 = runAura (namespaceOf <$> aurPkg "dwarffortress-ironhand") sampleSettings

--- a/src/Aura/Time.hs
+++ b/src/Aura/Time.hs
@@ -37,7 +37,7 @@ data Time = Time { yearOf   :: Integer
                  , dayOf    :: Int
                  , hourOf   :: Int
                  , minuteOf :: Int }
-            deriving (Eq,Show,Read)
+            deriving (Eq, Show, Read)
 
 months :: [String]
 months = [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"
@@ -52,8 +52,8 @@ toTime t = Time { yearOf   = ye
                 , dayOf    = da
                 , hourOf   = ho
                 , minuteOf = mi }
-    where (ye,mo,da) = toGregorian $ localDay t
-          (ho,mi)    = (todHour $ localTimeOfDay t, todMin $ localTimeOfDay t)
+    where (ye, mo, da) = toGregorian $ localDay t
+          (ho, mi)    = (todHour $ localTimeOfDay t, todMin $ localTimeOfDay t)
 
 dotFormat :: Time -> String
 dotFormat t = intercalate "." items

--- a/src/Aura/Utils.hs
+++ b/src/Aura/Utils.hs
@@ -105,10 +105,12 @@ splitName = fst . splitNameAndVer
 splitVer :: String -> String
 splitVer = snd . splitNameAndVer
 
-groupPkgs :: [([a], [b], [c])] -> ([a], [b], [c])
-groupPkgs = foldl groupPkgs' ([], [], [])
+groupPkgs :: (Foldable t, Monoid a, Monoid b, Monoid c) =>
+             t (a, b, c) -> (a, b, c)
+groupPkgs = foldl groupPkgs' (mempty, mempty, mempty)
 
-groupPkgs' :: ([a], [b], [c]) -> ([a], [b], [c]) -> ([a], [b], [c])
+groupPkgs' :: (Monoid a, Monoid b, Monoid c) =>
+              (a, b, c) -> (a, b, c) -> (a, b, c)
 groupPkgs' (ps, as, os) (p, a, o) = (p <> ps, a <> as, o <> os)
 
 sortPkgs :: [String] -> [String]

--- a/src/Aura/Utils/Numbers.hs
+++ b/src/Aura/Utils/Numbers.hs
@@ -26,6 +26,7 @@ module Aura.Utils.Numbers
     , version ) where
 
 import Text.ParserCombinators.Parsec
+import Data.Foldable
 
 import Utilities (eitherToMaybe, asInt)
 
@@ -34,9 +35,9 @@ import Utilities (eitherToMaybe, asInt)
 -- TODO: Move this to a unified `Types` file?
 data Version = Version { unitsOf    :: [Unit]
                        , revisionOf :: Maybe Int }  -- The number after `-`.
-               deriving (Eq,Show,Read,Ord)
+               deriving (Eq, Show, Read, Ord)
 
-data Unit = IUnit Int | SUnit String deriving (Eq,Show,Read,Ord)
+data Unit = IUnit Int | SUnit String deriving (Eq, Show, Read, Ord)
 
 version :: String -> Maybe Version
 version = eitherToMaybe . parse versionNumber ""
@@ -45,7 +46,7 @@ versionNumber :: Parser Version
 versionNumber = Version <$> units <*> optionMaybe revision
 
 units :: Parser [Unit]
-units = concat <$> (many1 (iunit <|> sunit) `sepBy` oneOf ".:_+")
+units = fold <$> (many1 (iunit <|> sunit) `sepBy` oneOf ".:_+")
 
 iunit :: Parser Unit
 iunit = IUnit . asInt <$> many1 digit

--- a/src/Bash/Base.hs
+++ b/src/Bash/Base.hs
@@ -21,6 +21,7 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Bash.Base where
 
+import Data.Monoid
 import qualified Data.Map.Lazy as M
 
 ---
@@ -31,11 +32,11 @@ data Field = Comment  String
            | IfBlock  BashIf
            | Variable String [BashString]
            | Command  String [BashString]
-             deriving (Eq,Show)
+             deriving (Eq, Show)
 
 data BashIf = If Comparison [Field] (Maybe BashIf)
             | Else [Field]
-              deriving (Eq,Show)
+              deriving (Eq, Show)
 
 data Comparison = CompEq BashString BashString
                 | CompNe BashString BashString
@@ -43,11 +44,11 @@ data Comparison = CompEq BashString BashString
                 | CompLe BashString BashString
                 | CompGt BashString BashString
                 | CompGe BashString BashString
-                  deriving (Eq,Show)
+                  deriving (Eq, Show)
 
 data BashFor = Incr  -- for (x;y;z); do ... done  -- Incomplete!
              | Iter String BashString [Field]  -- for x in y; do ... done
-               deriving (Eq,Show)
+               deriving (Eq, Show)
 
 -- | While `String` is the main data type in Bash, there are four
 -- subtypes each with different behaviour.
@@ -55,7 +56,7 @@ data BashString = SingleQ String
                 | DoubleQ String
                 | NoQuote String
                 | Backtic Field   -- Contains a Command.
-                  deriving (Eq,Show)
+                  deriving (Eq, Show)
 
 type Namespace = M.Map String [BashString]
 type Script    = [Field]  -- A parsed Bash script.
@@ -75,14 +76,14 @@ toNamespace (_:fs) = toNamespace fs
 getVar :: Namespace -> String -> Maybe [String]
 getVar ns s = case M.lookup s ns of
                 Nothing -> Nothing
-                Just bs -> Just $ map fromBashString bs
+                Just bs -> Just $ foldMap fromBashString bs
 
 fromBashString :: BashString -> String
 fromBashString (SingleQ s) = s
 fromBashString (DoubleQ s) = s
 fromBashString (NoQuote s) = s
-fromBashString (Backtic c) = '`' : fromCommand c ++ "`"
+fromBashString (Backtic c) = '`' : fromCommand c <> "`"
 
 fromCommand :: Field -> String
-fromCommand (Command c as) = unwords $ c : map fromBashString as
+fromCommand (Command c as) = unwords $ c : fromBashString <$> as
 fromCommand _ = error "Argument given was not a Command."

--- a/src/Bash/Parser.hs
+++ b/src/Bash/Parser.hs
@@ -28,6 +28,8 @@ module Bash.Parser ( parseBash ) where
 import Text.ParserCombinators.Parsec
 
 import Data.Maybe          (catMaybes)
+import Data.Monoid
+import Data.Foldable
 
 import Bash.Base
 
@@ -35,7 +37,7 @@ import Bash.Base
 
 parseBash :: String -> String -> Either ParseError [Field]
 parseBash p input = parse bashFile filename input
-    where filename = "(" ++ p ++ ")"
+    where filename = "(" <> p <> ")"
 
 -- | A Bash file could have many fields, or none.
 bashFile :: Parser [Field]
@@ -62,10 +64,10 @@ comment = Comment <$> comment' <?> "valid comment"
 command :: Parser Field
 command = spaces *> (Command <$> many1 commandChar <*> option [] (try args))
     where commandChar = alphaNum <|> oneOf "./"
-          args = char ' ' >> unwords <$> line >>= \ls ->
+          args = char ' ' *> (unwords <$> line >>= \ls ->
                    case parse (many1 single) "(command)" ls of
                      Left _   -> fail "Failed parsing strings in a command"
-                     Right bs -> return $ concat bs
+                     Right bs -> pure $ fold bs)
           line = (:) <$> many (noneOf "\n\\") <*> next
           next = ([] <$ char '\n') <|> (char '\\' *> spaces *> line)
 
@@ -83,7 +85,7 @@ variable = Variable <$> name <*> (blank <|> array <|> single) <?> "valid var def
           blank = [] <$ space
 
 array :: Parser [BashString]
-array = concat . catMaybes <$> array' <?> "valid array"
+array = fold . catMaybes <$> array' <?> "valid array"
     where array'  = char '(' *> spaces *> manyTill single' (char ')')
           single' = choice [ Nothing <$ comment <* spaces
                            , Nothing <$ many1 (space <|> char '\\')
@@ -98,13 +100,13 @@ single = (singleQuoted <|> doubleQuoted <|> backticked <|> try unQuoted)
 -- | Literal string. ${...} comes out as-is. No string extrapolation.
 singleQuoted :: Parser [BashString]
 singleQuoted = between (char '\'') (char '\'')
-               ((\s -> [SingleQ s]) <$> many1 (noneOf ['\n','\'']))
+               ((\s -> [SingleQ s]) <$> many1 (noneOf ['\n', '\'']))
                <?> "single quoted string"
 
 -- | Replaces ${...}. No string extrapolation.
 doubleQuoted :: Parser [BashString]
 doubleQuoted = between (char '"') (char '"')
-               ((\s -> [DoubleQ s]) <$> many1 (noneOf ['\n','"']))
+               ((\s -> [DoubleQ s]) <$> many1 (noneOf ['\n', '"']))
                <?> "double quoted string"
 
 -- | Contains commands.
@@ -114,7 +116,7 @@ backticked = between (char '`') (char '`') ((\c -> [Backtic c]) <$> command)
 
 -- | Replaces ${...}. Strings can be extrapolated!
 unQuoted :: Parser [BashString]
-unQuoted = map NoQuote <$> extrapolated []
+unQuoted = fmap NoQuote <$> extrapolated []
 
 -- | Bash strings are extrapolated when they contain a brace pair
 -- with two or more substrings separated by commas within them.
@@ -125,15 +127,15 @@ extrapolated :: [Char] -> Parser [String]
 extrapolated stops = do
   xs <- plain <|> bracePair
   ys <- option [""] $ try (extrapolated stops)
-  return [ x ++ y | x <- xs, y <- ys ]
-      where plain = (: []) `fmap` many1 (noneOf $ " \n{}()" ++ stops)
+  pure [ x <> y | x <- xs, y <- ys ]
+      where plain = (: []) <$> many1 (noneOf $ " \n{}()" <> stops)
 
 bracePair :: Parser [String]
 bracePair = between (char '{') (char '}') innards <?> "valid {...} string"
-    where innards = concatInnards <$> (extrapolated ",}" `sepBy` char ',')
-          concatInnards []   = ["{}"]
-          concatInnards [xs] = map (\s -> "{" ++ s ++ "}") xs
-          concatInnards xss  = concat xss
+    where innards = foldInnards <$> (extrapolated ",}" `sepBy` char ',')
+          foldInnards []   = ["{}"]
+          foldInnards [xs] = (\s -> "{" <> s <> "}") <$> xs
+          foldInnards xss  = fold xss
 
 ------------------
 -- `IF` STATEMENTS
@@ -151,12 +153,12 @@ realIfBlock' word sep =
 
 -- Inefficient?
 fiElifElse :: Parser (Maybe BashIf)
-fiElifElse = choice $ map (try . lookAhead) [fi, elif, elys]
+fiElifElse = choice (try . lookAhead <$> [fi, elif, elys])
 
 fi, elif, elys :: Parser (Maybe BashIf)
 fi   = Nothing <$  (string "fi" <* space)
 elif = Just    <$> realIfBlock' "elif " fiElifElse
-elys = Just    <$> (string "else" >> space >> Else `fmap` ifBody fi)
+elys = Just    <$> (string "else" *> space *> (Else <$> ifBody fi))
 
 ifCond :: Parser Comparison
 ifCond = comparison <* string "; then"
@@ -171,16 +173,16 @@ andStatement = do
   spaces
   cond <- comparison <* string " && "
   body <- field
-  return $ If cond [body] Nothing
+  pure $ If cond [body] Nothing
 
 comparison :: Parser Comparison
 comparison = do
-  spaces >> leftBs >> spaces
-  left <- head `fmap` single
+  spaces *> leftBs *> spaces
+  left <- head <$> single
   compOp <- comparisonOp
-  right <- head `fmap` single
+  right <- head <$> single
   rightBs
-  return (compOp left right) <?> "valid comparison"
+  pure (compOp left right) <?> "valid comparison"
       where leftBs  = skipMany1 $ char '['
             rightBs = skipMany1 $ char ']'
 

--- a/src/Bash/Simplify.hs
+++ b/src/Bash/Simplify.hs
@@ -82,10 +82,7 @@ replaceStr (Backtic f)   = Backtic <$> replace' f
 
 expandStr :: [Either BashExpansion String] -> State Namespace [String]
 expandStr [] = pure []
-expandStr (x:xs) = do
-  lhs <- expandStr' x
-  rhs <- expandStr xs
-  pure $ lhs <> rhs
+expandStr (x:xs) = (<>) <$> expandStr' x <*> expandStr xs
 
 expandStr' :: Either BashExpansion String -> State Namespace [String]
 expandStr' (Right s) = pure [s]

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -26,6 +26,7 @@ module Data.Algorithm.Diff
 
 import Prelude hiding (pi)
 
+import Data.Foldable
 import Data.Array
 
 data DI = F | S | B deriving (Show, Eq)
@@ -46,8 +47,8 @@ instance Ord DL
 canDiag :: (a -> a -> Bool) -> [a] -> [a] -> Int -> Int -> Int -> Int -> Bool
 canDiag eq as bs lena lenb = \ i j ->
    if i < lena && j < lenb then (arAs ! i) `eq` (arBs ! j) else False
-    where arAs = listArray (0,lena - 1) as
-          arBs = listArray (0,lenb - 1) bs
+    where arAs = listArray (0, lena - 1) as
+          arBs = listArray (0, lenb - 1) bs
 
 dstep :: (Int -> Int -> Bool) -> [DL] -> [DL]
 dstep cd dls = hd:pairMaxes rst
@@ -70,8 +71,8 @@ addsnake cd dl
 
 lcs :: (a -> a -> Bool) -> [a] -> [a] -> [DI]
 lcs eq as bs = path . head . dropWhile (\dl -> poi dl /= lena || poj dl /= lenb) .
-            concat . iterate (dstep cd) . (:[]) . addsnake cd $
-            DL {poi=0,poj=0,path=[]}
+            fold . iterate (dstep cd) . (:[]) . addsnake cd $
+                DL {poi=0, poj=0, path=[]}
             where cd = canDiag eq as bs lena lenb
                   lena = length as; lenb = length bs
 
@@ -104,10 +105,10 @@ getGroupedDiffBy eq a b = go $ getDiffBy eq a b
           go [] = []
 
           goFirsts  (First x  : xs) = let (fs, rest) = goFirsts  xs in (x:fs, rest)
-          goFirsts  xs = ([],xs)
+          goFirsts  xs = ([], xs)
 
           goSeconds (Second x : xs) = let (fs, rest) = goSeconds xs in (x:fs, rest)
-          goSeconds xs = ([],xs)
+          goSeconds xs = ([], xs)
 
-          goBoth    (Both x y : xs) = let (fs, rest) = goBoth xs    in ((x,y):fs, rest)
-          goBoth    xs = ([],xs)
+          goBoth    (Both x y : xs) = let (fs, rest) = goBoth xs    in ((x, y):fs, rest)
+          goBoth    xs = ([], xs)

--- a/src/Internet.hs
+++ b/src/Internet.hs
@@ -40,9 +40,9 @@ saveUrlContents :: FilePath -> String -> IO (Maybe FilePath)
 saveUrlContents fpath url = do
   contents <- urlContents url
   case contents of
-    Nothing -> return Nothing
+    Nothing -> pure Nothing
     Just c  -> do
       handle <- openFile filePath WriteMode
-      L.hPutStr handle c >> hClose handle >> return (Just filePath)
+      L.hPutStr handle c *> hClose handle *> pure (Just filePath)
           where filePath = fpath </> file
-                (_,file) = splitFileName url
+                (_, file) = splitFileName url

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -28,9 +28,11 @@ import Control.Concurrent  (threadDelay)
 import System.Directory    (doesFileExist)
 import System.FilePath     (dropExtension)
 import Text.Regex.PCRE     ((=~))
-import Control.Monad       (void)
+import Data.Functor
+import Data.Monoid
 import Text.Printf         (printf)
 import Data.List           (dropWhileEnd)
+import Data.Foldable
 import Data.Char           (digitToInt)
 import System.IO
 
@@ -38,7 +40,7 @@ import Shell
 
 ---
 
-type Pattern = (String,String)
+type Pattern = (String, String)
 
 type Regex = String
 
@@ -54,8 +56,8 @@ split x xs = fst xs' : split x (snd xs')
     where xs' = hardBreak (== x) xs
 
 -- | Like break, but kills the element that triggered the break.
-hardBreak :: (a -> Bool) -> [a] -> ([a],[a])
-hardBreak _ [] = ([],[])
+hardBreak :: (a -> Bool) -> [a] -> ([a], [a])
+hardBreak _ [] = ([], [])
 hardBreak p xs = (firstHalf, secondHalf')
     where firstHalf   = takeWhile (not . p) xs
           secondHalf  = dropWhile (not . p) xs
@@ -69,13 +71,13 @@ rStrip = dropWhileEnd (`elem` whitespaces)
 -- The Int argument is the final length of the padded String,
 -- not the length of the pad. Is that stupid?
 postPad :: [a] -> a -> Int -> [a]
-postPad xs x len = take len $ xs ++ repeat x
+postPad xs x len = take len $ xs <> repeat x
 
 prePad :: [a] -> a -> Int -> [a]
-prePad xs x len = replicate (len - length xs) x ++ xs
+prePad xs x len = replicate (len - length xs) x <> xs
 
 whitespaces :: [Char]
-whitespaces = [' ','\t']
+whitespaces = [' ', '\t']
 
 asInt :: String -> Int
 asInt = foldl (\acc i -> acc * 10 + digitToInt i) 0
@@ -84,14 +86,14 @@ asInt = foldl (\acc i -> acc * 10 + digitToInt i) 0
 -- TUPLES
 ---------
 -- I'm surprised the following three functions don't already exist.
-tripleFst :: (a,b,c) -> a
-tripleFst (a,_,_) = a
+tripleFst :: (a, b, c) -> a
+tripleFst (a, _, _) = a
 
-tripleSnd :: (a,b,c) -> b
-tripleSnd (_,b,_) = b
+tripleSnd :: (a, b, c) -> b
+tripleSnd (_, b, _) = b
 
-tripleThrd :: (a,b,c) -> c
-tripleThrd (_,_,c) = c
+tripleThrd :: (a, b, c) -> c
+tripleThrd (_, _, c) = c
 
 ---------
 -- EITHER
@@ -111,9 +113,9 @@ eitherToMaybe (Right x) = Just x
 -- | Replaces a (p)attern with a (t)arget in a line if possible.
 replaceByPatt :: [Pattern] -> String -> String
 replaceByPatt [] line = line
-replaceByPatt ((p,t):ps) line | p == m    = replaceByPatt ps (b ++ t ++ a)
+replaceByPatt ((p, t):ps) line | p == m    = replaceByPatt ps (b <> t <> a)
                               | otherwise = replaceByPatt ps line
-                         where (b,m,a) = line =~ p :: (String,String,String)
+                         where (b, m, a) = line =~ p :: (String, String, String)
 
 searchLines :: Regex -> [String] -> [String]
 searchLines pat = filter (=~ pat)
@@ -121,12 +123,12 @@ searchLines pat = filter (=~ pat)
 --------------------
 -- Association Lists
 --------------------
-alElem :: Eq k => k -> [(k,a)] -> Bool
+alElem :: Eq k => k -> [(k, a)] -> Bool
 alElem k al = case lookup k al of
                 Nothing -> False
                 Just _  -> True
 
-alNotElem :: Eq k => k -> [(k,a)] -> Bool
+alNotElem :: Eq k => k -> [(k, a)] -> Bool
 alNotElem k = not . alElem k
 
 -----
@@ -134,24 +136,24 @@ alNotElem k = not . alElem k
 -----
 -- | Given a number of selections, allows the user to choose one.
 getSelection :: [String] -> IO String
-getSelection [] = return ""
+getSelection [] = pure ""
 getSelection choiceLabels = do
   let quantity = length choiceLabels
-      valids   = map show [1..quantity]
+      valids   = show <$> [1..quantity]
       padding  = show . length . show $ quantity
       choices  = zip valids choiceLabels
-  mapM_ (uncurry (printf ("%" ++ padding ++ "s. %s\n"))) choices
+  traverse_ (uncurry (printf ("%" <> padding <> "s. %s\n"))) choices
   putStr ">> "
   hFlush stdout
   userChoice <- getLine
   case userChoice `lookup` choices of
-    Just valid -> return valid
+    Just valid -> pure valid
     Nothing    -> getSelection choiceLabels  -- Ask again.
 
 -- | Print a list of Strings with a given interval in between.
 timedMessage :: Int -> [String] -> IO ()
-timedMessage delay = mapM_ printMessage
-    where printMessage msg = putStr msg >> hFlush stdout >> threadDelay delay
+timedMessage delay = traverse_ printMessage
+    where printMessage msg = putStr msg *> hFlush stdout *> threadDelay delay
 
 notNull :: [a] -> Bool
 notNull = not . null
@@ -164,15 +166,15 @@ openEditor editor file = void $ shellCmd editor [file]
 -- Thus calling dropExtension twice should remove that section.
 decompress :: FilePath -> IO FilePath
 decompress file = do
-  _ <- quietShellCmd' "bsdtar" ["-zxvf",file]
-  return . dropExtension . dropExtension $ file
+  _ <- quietShellCmd' "bsdtar" ["-zxvf", file]
+  pure . dropExtension . dropExtension $ file
 
 -- | Perform an action within a given directory.
 inDir :: FilePath -> IO a -> IO a
-inDir dir io = pwd >>= \cur -> cd dir >> io >>= \res -> cd cur >> return res
+inDir dir io = pwd >>= \cur -> cd dir *> io >>= \res -> cd cur *> pure res
 
 noDots :: [String] -> [String]
-noDots = filter (`notElem` [".",".."])
+noDots = filter (`notElem` [".", ".."])
 
 -- | Read a file with the given encoding.
 readFileEncoding :: TextEncoding -> FilePath -> IO String
@@ -189,32 +191,29 @@ readFileUTF8 = readFileEncoding utf8
 -- MONADS
 ---------
 -- These functions need to be organized better!
--- | Simple control flow for Monads.
-ifM :: Monad m => m Bool -> (x -> m x) -> m () -> x -> m x
-ifM cond a1 a2 x = do
-  success <- cond
-  if success then a1 x else a2 >> return x
 
--- | When `False`, returns the second `x` argument instead.
-ifM2 :: Monad m => m Bool -> (x -> m x) -> m () -> x -> x -> m x
-ifM2 cond a1 a2 x1 x2 = do
-  success <- cond
-  if success then a1 x1 else a2 >> return x2
+-- | `if then else` in a function.
+ifte :: Bool -> a -> a -> a
+ifte cond t f = if cond then t else f
+
+-- | `ifte` with the condition at the end.
+ifte_ :: a -> a -> Bool -> a
+ifte_ t f cond = ifte cond t f
 
 -- | Like `when`, but with a Monadic condition.
-whenM :: Monad m => m Bool -> m () -> m ()
-whenM cond a = cond >>= \success -> if success then a else nothing
+whenM :: Monad m => m Bool -> m a -> m ()
+whenM cond' a = cond' >>= ifte_ (void a) nothing
 
 -- | Monadic 'find'. We can't use 'filterM' because monads like 'IO' can
 -- be strict.
 findM :: Monad m => (a -> m Bool) -> [a] -> m (Maybe a)
-findM _ []     = return Nothing
-findM p (x:xs) = p x >>= \found -> if found then return (Just x) else findM p xs
+findM _ []     = pure Nothing
+findM p (x:xs) = p x >>= ifte_ (pure $ Just x) (findM p xs)
 
--- | If a file exists, it performs action `a`.
--- If the file doesn't exist, it performs `b` and returns the argument.
-ifFile :: MonadIO m => (x -> m x) -> m () -> FilePath -> x -> m x
-ifFile a1 a2 file x = ifM (liftIO $ doesFileExist file) a1 a2 x
+-- | If a file exists, it performs action `t` on the argument.
+-- | If the file doesn't exist, it performs `f` and returns the argument.
+ifFile :: MonadIO m => (a -> m a) -> m b -> FilePath -> a -> m a
+ifFile t f file x = (liftIO $ doesFileExist file) >>= ifte_ (t $ x) (f $> x)
 
 nothing :: Monad m => m ()
-nothing = return ()
+nothing = pure ()

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -70,8 +70,8 @@ rStrip = dropWhileEnd (`elem` whitespaces)
 
 -- The Int argument is the final length of the padded String,
 -- not the length of the pad. Is that stupid?
-postPad :: [a] -> a -> Int -> [a]
-postPad xs x len = take len $ xs <> repeat x
+postPad :: String -> String -> Int -> String
+postPad str pad len = str <> fold (take (len - length str) $ repeat pad)
 
 prePad :: [a] -> a -> Int -> [a]
 prePad xs x len = replicate (len - length xs) x <> xs
@@ -215,5 +215,5 @@ findM p (x:xs) = p x >>= ifte_ (pure $ Just x) (findM p xs)
 ifFile :: MonadIO m => (a -> m a) -> m b -> FilePath -> a -> m a
 ifFile t f file x = (liftIO $ doesFileExist file) >>= ifte_ (t $ x) (f $> x)
 
-nothing :: Monad m => m ()
+nothing :: Applicative f => f ()
 nothing = pure ()

--- a/src/aura.hs
+++ b/src/aura.hs
@@ -33,6 +33,8 @@ import System.Environment (getArgs)
 import Control.Monad      (when)
 import System.Exit        (exitSuccess, exitFailure)
 import Data.List          (nub, sort, intercalate)
+import Data.Foldable      (traverse_)
+import Data.Monoid        ((<>))
 
 import Aura.Colour.Text (yellow)
 import Aura.Shell       (shellCmd)
@@ -58,7 +60,7 @@ import Aura.Commands.O as O
 
 ---
 
-type UserInput = ([Flag],[String],[String])
+type UserInput = ([Flag], [String], [String])
 
 auraVersion :: String
 auraVersion = "1.3.2.1"
@@ -66,26 +68,26 @@ auraVersion = "1.3.2.1"
 main :: IO a
 main = getArgs >>= prepSettings . processFlags >>= execute >>= exit
 
-processFlags :: [String] -> (UserInput,Maybe Language)
-processFlags args = ((flags,nub input,pacOpts'),language)
-    where (language,_) = parseLanguageFlag args
-          (flags,input,pacOpts) = parseFlags language args
-          pacOpts' = nub $ pacOpts ++ reconvertFlags dualFlagMap flags
-                   ++ reconvertFlags pacmanFlagMap flags
+processFlags :: [String] -> (UserInput, Maybe Language)
+processFlags args = ((flags, nub input, pacOpts'), language)
+    where (language, _) = parseLanguageFlag args
+          (flags, input, pacOpts) = parseFlags language args
+          pacOpts' = nub $ pacOpts <> reconvertFlags dualFlagMap flags
+                   <> reconvertFlags pacmanFlagMap flags
 
 -- | Set the local environment.
-prepSettings :: (UserInput,Maybe Language) -> IO (UserInput,Settings)
-prepSettings (ui,lang) = (,) ui `fmap` getSettings lang ui
+prepSettings :: (UserInput, Maybe Language) -> IO (UserInput, Settings)
+prepSettings (ui, lang) = (,) ui <$> getSettings lang ui
 
 -- | Hand user input to the Aura Monad and run it.
-execute :: (UserInput,Settings) -> IO (Either String ())
-execute ((flags,input,pacOpts),ss) = do
+execute :: (UserInput, Settings) -> IO (Either String ())
+execute ((flags, input, pacOpts), ss) = do
   let flags' = filter notSettingsFlag flags
   when (Debug `elem` flags) $ debugOutput ss
-  runAura (executeOpts (flags',input,pacOpts)) ss
+  runAura (executeOpts (flags', input, pacOpts)) ss
 
 exit :: Either String () -> IO a
-exit (Left e)  = putStrLn e >> exitFailure
+exit (Left e)  = putStrLn e *> exitFailure
 exit (Right _) = exitSuccess
 
 -- | After determining what Flag was given, dispatches a function.
@@ -94,8 +96,8 @@ exit (Right _) = exitSuccess
 -- If no matches on Aura flags are found, the flags are assumed to be
 -- pacman's.
 executeOpts :: UserInput -> Aura ()
-executeOpts ([],_,[]) = executeOpts ([Help],[],[])
-executeOpts (flags,input,pacOpts) =
+executeOpts ([], _, []) = executeOpts ([Help], [], [])
+executeOpts (flags, input, pacOpts) =
   case sort flags of
     (AURInstall:fs) ->
         case fs of
@@ -106,7 +108,7 @@ executeOpts (flags,input,pacOpts) =
           [ViewDeps]     -> A.displayPkgDeps input
           [Download]     -> A.downloadTarballs input
           [GetPkgbuild]  -> A.displayPkgbuild input
-          (Refresh:fs')  -> sudo $ syncAndContinue (fs',input,pacOpts)
+          (Refresh:fs')  -> sudo $ syncAndContinue (fs', input, pacOpts)
           _              -> scoldAndFail executeOpts_1
     (ABSInstall:fs) ->
         case fs of
@@ -117,7 +119,7 @@ executeOpts (flags,input,pacOpts) =
           [Clean]        -> sudo M.cleanABSTree
           [ViewDeps]     -> M.displayPkgDeps input
           [GetPkgbuild]  -> M.displayPkgbuild input
-          (Refresh:fs')  -> sudo $ syncABSAndContinue (fs',input,pacOpts)
+          (Refresh:fs')  -> sudo $ syncABSAndContinue (fs', input, pacOpts)
           _              -> scoldAndFail executeOpts_1
     (SaveState:fs) ->
         case fs of
@@ -129,7 +131,7 @@ executeOpts (flags,input,pacOpts) =
         case fs of
           []             -> sudo $ C.downgradePackages pacOpts input
           [Clean]        -> sudo $ C.cleanCache input
-          [Clean,Clean]  -> sudo C.cleanNotSaved
+          [Clean, Clean]  -> sudo C.cleanNotSaved
           [Search]       -> C.searchCache input
           [CacheBackup]  -> sudo $ C.backupCache input
           _              -> scoldAndFail executeOpts_1
@@ -148,18 +150,18 @@ executeOpts (flags,input,pacOpts) =
     [Languages] -> displayOutputLanguages
     [Help]      -> printHelpMsg pacOpts
     [Version]   -> getVersionInfo >>= animateVersionMsg
-    _ -> catch (pacman $ pacOpts ++ hijackedFlags ++ input) pacmanFailure
+    _ -> catch (pacman $ pacOpts <> hijackedFlags <> input) pacmanFailure
     where hijackedFlags = reconvertFlags hijackedFlagMap flags
 
 -- | `-y` was included with `-A`. Sync database before continuing.
 syncAndContinue :: UserInput -> Aura ()
-syncAndContinue (flags,input,pacOpts) =
-  syncDatabase pacOpts >> executeOpts (AURInstall:flags,input,pacOpts)
+syncAndContinue (flags, input, pacOpts) =
+  syncDatabase pacOpts *> executeOpts (AURInstall:flags, input, pacOpts)
 
 -- | `-y` was included with `-M`. Sync local ABS tree before continuing.
 syncABSAndContinue :: UserInput -> Aura ()
-syncABSAndContinue (flags,input,pacOpts) =
-  M.absSync >> executeOpts (ABSInstall:flags,input,pacOpts)
+syncABSAndContinue (flags, input, pacOpts) =
+  M.absSync *> executeOpts (ABSInstall:flags, input, pacOpts)
 
 ----------
 -- GENERAL
@@ -170,42 +172,42 @@ viewConfFile = shellCmd "less" [pacmanConfFile]
 displayOutputLanguages :: Aura ()
 displayOutputLanguages = do
   notify displayOutputLanguages_1
-  liftIO $ mapM_ print allLanguages
+  liftIO $ traverse_ print allLanguages
 
 printHelpMsg :: [String] -> Aura ()
 printHelpMsg [] = ask >>= \ss -> do
   pacmanHelp <- getPacmanHelpMsg
   liftIO . putStrLn . getHelpMsg ss $ pacmanHelp
-printHelpMsg pacOpts = pacman $ pacOpts ++ ["-h"]
+printHelpMsg pacOpts = pacman $ pacOpts <> ["-h"]
 
 getHelpMsg :: Settings -> [String] -> String
 getHelpMsg settings pacmanHelpMsg = intercalate "\n" allMessages
     where lang = langOf settings
           allMessages   = [replacedLines, auraOperMsg lang, manpageMsg lang]
-          replacedLines = unlines $ map (replaceByPatt patterns) pacmanHelpMsg
+          replacedLines = unlines (replaceByPatt patterns <$> pacmanHelpMsg)
           colouredMsg   = yellow $ inheritedOperTitle lang
-          patterns      = [("pacman","aura"), ("operations",colouredMsg)]
+          patterns      = [("pacman", "aura"), ("operations", colouredMsg)]
 
 -- | Animated version message.
 animateVersionMsg :: [String] -> Aura ()
 animateVersionMsg verMsg = ask >>= \ss -> liftIO $ do
   hideCursor
-  mapM_ (putStrLn . padString verMsgPad) verMsg  -- Version message
+  traverse_ (putStrLn . padString verMsgPad) verMsg  -- Version message
   raiseCursorBy 7  -- Initial reraising of the cursor.
   drawPills 3
-  mapM_ putStrLn $ renderPacmanHead 0 Open  -- Initial rendering of head.
+  traverse_ putStrLn $ renderPacmanHead 0 Open  -- Initial rendering of head.
   raiseCursorBy 4
   takeABite 0  -- Initial bite animation.
-  mapM_ pillEating pillsAndWidths
+  traverse_ pillEating pillsAndWidths
   clearGrid
   version ss
   showCursor
-    where pillEating (p,w) = clearGrid >> drawPills p >> takeABite w
-          pillsAndWidths   = [(2,5),(1,10),(0,15)]
+    where pillEating (p, w) = clearGrid *> drawPills p *> takeABite w
+          pillsAndWidths   = [(2, 5), (1, 10), (0, 15)]
 
 version :: Settings -> IO ()
 version ss = do
   putStrLn auraLogo
-  putStrLn $ "AURA Version " ++ auraVersion
+  putStrLn $ "AURA Version " <> auraVersion
   putStrLn " by Colin Woodbury\n"
-  mapM_ putStrLn . translatorMsg . langOf $ ss
+  traverse_ putStrLn . translatorMsg . langOf $ ss

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- aur-4.0.0
+- aur-4.0.2
 resolver: lts-3.1


### PR DESCRIPTION
Probably what will end up being early stages right now, but a PR to just generally clean up aura.
* [x] `map` → `fmap` (and `<$>` where appropriate)
* [x] `return` → `pure`
* [x] `>>` → `*>` (and `$>` where appropriate)
* [x] `(a,b)` → `(a, b)`
* [x] List funs → Foldable/Traversable funs
* [x] Monad funs → Functor/Applicative funs
* [ ] Generic types (e.g. `Monad m => m ()` where it really could just be a free `m a`)
* [ ] Imports