### PR TITLE
[aura-1.4] Prelude ==> BasicPrelude && Formatting ==> th-printf

### DIFF
--- a/aura.cabal
+++ b/aura.cabal
@@ -44,6 +44,8 @@ executable aura
   default-extensions:  Rank2Types
                        FlexibleContexts
                        OverloadedStrings
+                       NoImplicitPrelude
+                       QuasiQuotes
 
   default-language:    Haskell2010
 
@@ -94,12 +96,12 @@ executable aura
                        array,
                        attoparsec,
                        base >= 4.8 && < 5,
+                       basic-prelude,
                        bytestring,
                        containers,
                        directory,
                        extensible-effects,
                        filepath,
-                       formatting,
                        lens,
                        megaparsec,
                        process,
@@ -111,6 +113,7 @@ executable aura
                        temporary,
                        text,
                        text-icu,
+                       th-printf,
                        ini,
                        time,
                        transformers,

--- a/src/Aura/Bash.hs
+++ b/src/Aura/Bash.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- Interface to the Bash library.
 
 {-
@@ -24,11 +23,12 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Bash
     ( namespace
-    , value 
+    , value
     , Namespace ) where
 
+import BasicPrelude hiding (liftIO, insert)
+
 import Text.Megaparsec.Error (ParseError)
-import Data.Maybe    (fromMaybe)
 
 import Aura.Settings.Base
 import Aura.Monad.Aura

--- a/src/Aura/Build.hs
+++ b/src/Aura/Build.hs
@@ -25,8 +25,8 @@ module Aura.Build
     ( installPkgFiles
     , buildPackages ) where
 
-import Control.Monad (void)
-import Data.Monoid ((<>))
+import BasicPrelude hiding (FilePath, catch, liftIO, (</>))
+
 import qualified Data.Text as T
 
 import Aura.Colour.Text
@@ -43,7 +43,6 @@ import Aura.Shell
 import Shelly hiding (liftIO)
 import qualified Filesystem.Path.CurrentOS as F
 import qualified Data.Text.IO as IO
-import Prelude hiding (FilePath)
 
 ---
 

--- a/src/Aura/Cache.hs
+++ b/src/Aura/Cache.hs
@@ -34,9 +34,10 @@ module Aura.Cache
     , Cache
     , SimplePkg ) where
 
+import           BasicPrelude hiding (FilePath)
+
 import qualified Data.Map.Lazy as M
 import qualified Data.Text as T
-import           Data.List (nub)
 
 import           Aura.Monad.Aura
 import           Aura.Settings.Base
@@ -45,8 +46,6 @@ import           Aura.Utils.Numbers (Version)
 
 import           Utilities (searchLinesF)
 import           Shelly    (FilePath, ls)
-import           Prelude hiding (FilePath)
-
 ---
 
 type SimplePkg = (T.Text, Maybe Version)

--- a/src/Aura/Colour/Text.hs
+++ b/src/Aura/Colour/Text.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-
 
 Copyright 2012, 2013, 2014 Colin Woodbury <colingw@gmail.com>
@@ -22,9 +21,9 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Colour.Text where
 
-import Data.Monoid
-import qualified Data.Text as T
+import BasicPrelude
 
+import qualified Data.Text as T
 ---
 
 -- ANSI codes referenced from: www.bluesock.org/~willg/dev/ansi.html
@@ -38,7 +37,7 @@ type Colouror = T.Text -> T.Text
 
 -- Code borrowed from `ansi-terminal` library by Max Bolingbroke.
 csi :: [Int] -> T.Text -> T.Text
-csi args code = "\ESC[" <> T.intercalate ";" (T.pack . show <$> args) <> code
+csi args code = "\ESC[" <> T.intercalate ";" (show <$> args) <> code
 
 noColour :: Colouror
 noColour = colourize NoColour

--- a/src/Aura/Commands/B.hs
+++ b/src/Aura/Commands/B.hs
@@ -24,6 +24,8 @@ module Aura.Commands.B
     , restoreState
     , cleanStates ) where
 
+import BasicPrelude hiding ((</>))
+
 import Shelly ((</>),rm)
 import Data.Char       (isDigit)
 import Data.Foldable   (traverse_)

--- a/src/Aura/Commands/C.hs
+++ b/src/Aura/Commands/C.hs
@@ -30,16 +30,14 @@ module Aura.Commands.C
     , cleanCache
     , cleanNotSaved ) where
 
+import BasicPrelude hiding (FilePath, liftIO, (</>))
+
 import Shelly    (FilePath, (</>), rm, cp, fromText, toTextIgnore)
 import qualified Data.Text.ICU as Re
 import qualified Data.Text.IO as IO
 import Data.Text.Read
-import Control.Monad      (unless)
-import Data.List          ((\\), sort, groupBy)
 import Data.Foldable      (traverse_, fold)
 import Data.Char          (isDigit)
-import Data.Monoid        ((<>))
-import Data.Maybe         (isJust,fromMaybe)
 
 import Aura.Logo   (raiseCursorBy)
 import Aura.Pacman (pacman)
@@ -54,8 +52,6 @@ import Aura.Core
 import Utilities
 
 import qualified Data.Text as T
-import Prelude hiding (FilePath)
-
 ---
 
 -- | Interactive. Gives the user a choice as to exactly what versions

--- a/src/Aura/Commands/M.hs
+++ b/src/Aura/Commands/M.hs
@@ -55,9 +55,9 @@ module Aura.Commands.M
     , displayPkgbuild
     , displayPkgDeps ) where
 
+import BasicPrelude hiding (liftIO)
+
 import Control.Monad
-import Data.Maybe       (catMaybes, fromMaybe)
-import Data.Monoid      ((<>))
 import Data.Foldable    (traverse_)
 import qualified Data.Text as T
 import qualified Data.Text.IO as IO

--- a/src/Aura/Commands/O.hs
+++ b/src/Aura/Commands/O.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- Handles all `-O` operations
 
 {-
@@ -26,10 +25,10 @@ module Aura.Commands.O
     ( displayOrphans
     , adoptPkg ) where
 
-import Data.Monoid
+import BasicPrelude hiding (liftIO)
+
 import Data.Foldable
 import qualified Data.Text as T
-import qualified Data.Text.IO as IO
 
 import Aura.Core   (orphans, sudo)
 import Aura.Pacman (pacman)
@@ -38,7 +37,7 @@ import Aura.Monad.Aura
 ---
 
 displayOrphans :: [T.Text] -> Aura ()
-displayOrphans []   = orphans >>= liftIO . traverse_ IO.putStrLn
+displayOrphans []   = orphans >>= liftIO . traverse_ putStrLn
 displayOrphans pkgs = adoptPkg pkgs
 
 adoptPkg :: [T.Text] -> Aura ()

--- a/src/Aura/Conflicts.hs
+++ b/src/Aura/Conflicts.hs
@@ -22,8 +22,8 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Conflicts where
 
-import Data.Maybe (isNothing)
-import Data.Monoid ((<>))
+import BasicPrelude
+
 import Data.Foldable (traverse_)
 import qualified Data.Text as T
 import qualified Data.Text.ICU as Re
@@ -57,7 +57,7 @@ realPkgConflicts ss pkg dep
           lang     = langOf ss
           toIgnore = ignoredPkgsOf ss
           failMsg1 = getRealPkgConflicts_2 name lang
-          failMsg2 = getRealPkgConflicts_1 name curVer (T.pack $ show reqVer) lang
+          failMsg2 = getRealPkgConflicts_1 name curVer (show reqVer) lang
 
 -- Compares a (r)equested version number with a (c)urrent up-to-date one.
 -- The `MustBe` case uses regexes. A dependency demanding version 7.4

--- a/src/Aura/Core.hs
+++ b/src/Aura/Core.hs
@@ -22,10 +22,9 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Core where
 
-import Data.Either      (partitionEithers)
-import Data.Monoid
+import BasicPrelude hiding (FilePath, span, liftIO)
+
 import qualified Data.Text as T
-import qualified Data.Text.IO as IO
 
 import Aura.Settings.Base
 import Aura.Colour.Text
@@ -36,8 +35,8 @@ import Aura.Utils
 
 import Aura.Shell
 import Shelly hiding (find, liftIO)
-import Prelude hiding (FilePath, span)
 import Utilities (exists)
+import qualified Prelude (Show, show)
 
 ---
 
@@ -54,11 +53,11 @@ data VersionDemand = LessThan T.Text
                    | Anything
                      deriving (Eq)
 
-instance Show VersionDemand where
-    show (LessThan v) = show ("<" <> v)
-    show (AtLeast v)  = show (">=" <> v)
-    show (MoreThan v) = show (">" <> v)
-    show (MustBe  v)  = show ("=" <> v)
+instance Prelude.Show VersionDemand where
+    show (LessThan v) = "<" <> T.unpack v
+    show (AtLeast v)  = ">=" <> T.unpack v
+    show (MoreThan v) = ">" <> T.unpack v
+    show (MustBe  v)  = "=" <> T.unpack v
     show Anything     = ""
 
 -- | A package to be installed.
@@ -166,13 +165,13 @@ removePkgs pkgs pacOpts = pacman  $ ["-Rsu"] <> pkgs <> pacOpts
 -- Moving to a libalpm backend will make this less hacked.
 -- | True if a dependency is satisfied by an installed package.
 isSatisfied :: Dep -> Aura Bool
-isSatisfied (Dep name ver) = T.null <$> pacmanOutput ["-T", name <> T.pack (show ver)]
+isSatisfied (Dep name ver) = T.null <$> pacmanOutput ["-T", name <> show ver]
 
 -- | Block further action until the database is free.
 checkDBLock :: Aura ()
 checkDBLock = do
   locked <- liftShelly $ exists lockFile
-  when locked $ warn checkDBLock_1 *> liftIO IO.getLine *> checkDBLock
+  when locked $ warn checkDBLock_1 *> liftIO getLine *> checkDBLock
 
 -------
 -- MISC  -- Too specific for `Utilities.hs` or `Aura.Utils`

--- a/src/Aura/Dependencies.hs
+++ b/src/Aura/Dependencies.hs
@@ -24,10 +24,11 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Dependencies ( resolveDeps ) where
 
+import           BasicPrelude hiding (liftIO)
+
 import           Control.Eff.State.Strict
 import           Control.Eff
 import           Data.Graph
-import           Data.Maybe
 import qualified Data.Map as Map
 import           Data.Foldable
 import qualified Data.Text as T

--- a/src/Aura/Diff.hs
+++ b/src/Aura/Diff.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-
 
 Copyright 2012, 2013, 2014 Colin Woodbury <colingw@gmail.com>
@@ -23,9 +22,9 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 -- | Coloured diff output, similar to @diff -u@ or @git diff@.
 module Aura.Diff ( unidiff ) where
 
-import Data.Traversable    (mapAccumL)
+import BasicPrelude
+
 import qualified Data.Text as T
-import Data.Monoid         ((<>))
 
 import Data.Algorithm.Diff
 
@@ -142,7 +141,7 @@ hunkRanges xs = (LineRange a a', LineRange b b')
         mapRanges f c = (f $ firstRange c, f $ secondRange c)
 
 showRange :: LineRange -> T.Text
-showRange r = T.pack (show (start r)) <> "," <> T.pack (show (rangeLength r))
+showRange r = show (start r) <> "," <> show (rangeLength r)
 
 showBlock :: Block -> [T.Text]
 showBlock b = f . (c <>) <$> content b

--- a/src/Aura/Flags.hs
+++ b/src/Aura/Flags.hs
@@ -51,10 +51,10 @@ module Aura.Flags
     , auraOperMsg
     , Flag(..) ) where
 
+import BasicPrelude hiding (FilePath)
+
 import System.Console.GetOpt
-import Data.Monoid
 import Data.Foldable
-import Data.Maybe (fromMaybe)
 import Text.Read (readMaybe)
 import qualified Data.Text as T
 
@@ -63,7 +63,6 @@ import Aura.Settings.Base
 import Aura.Languages
 
 import Shelly (FilePath, fromText)
-import Prelude hiding (FilePath)
 
 ---
 

--- a/src/Aura/Install.hs
+++ b/src/Aura/Install.hs
@@ -29,12 +29,9 @@ module Aura.Install
     , displayPkgbuild
     ) where
 
-import Control.Monad (filterM, (>=>))
-import Data.Either   (partitionEithers)
-import Data.List     (sort, (\\), intersperse, partition)
+import BasicPrelude hiding (FilePath, catch, liftIO)
+
 import Data.Foldable (traverse_)
-import Data.Maybe    (catMaybes)
-import Data.Monoid   ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as IO
 
@@ -50,7 +47,6 @@ import Aura.Build
 import Aura.Utils
 import Aura.Core
 import Shelly hiding (liftIO)
-import Prelude hiding (FilePath)
 
 ---
 

--- a/src/Aura/Languages.hs
+++ b/src/Aura/Languages.hs
@@ -41,12 +41,11 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Languages where
 
+import BasicPrelude hiding (FilePath)
+
 import Aura.Colour.Text (cyan, green, red, blue, yellow, magenta, bForeground)
 import qualified Data.Map.Lazy as Map (Map, (!), fromList, toList, mapWithKey)
-import Data.Monoid
 import qualified Data.Text as T
-import Formatting
-import Prelude hiding (FilePath)
 import Shelly (FilePath,toTextIgnore)
 
 ---
@@ -924,7 +923,7 @@ cleanStates_1 = \case
 
 -- NEEDS TRANSLATION
 cleanStates_2 :: Int -> Language -> T.Text
-cleanStates_2 (bt . T.pack . show -> n) = \case
+cleanStates_2 (bt . show -> n) = \case
     Japanese   -> n <> "個のパッケージ状態記録だけが残される。その他削除？"
     Croatian   -> n <> " stanja paketa će biti zadržano. Ukloniti ostatak?"
     German     -> n <> " Paketzustände werden behalten. Den Rest entfernen?"
@@ -1041,7 +1040,7 @@ backupCache_4 (bt . toTextIgnore -> dir) = \case
     _          -> "Backing up cache to " <> dir
 
 backupCache_5 :: Int -> Language -> T.Text
-backupCache_5 (bt . sformat int -> n) = \case
+backupCache_5 (bt . show -> n) = \case
     Japanese   -> "パッケージのファイル数：" <> n
     Polish     -> "Pliki będące częścią\xa0kopii zapasowej: " <> n
     Croatian   -> "Datoteke koje su dio sigurnosne kopije: " <> n
@@ -1109,7 +1108,7 @@ backupCache_8 = \case
     _          -> "Backing up. This may take a few minutes..."
 
 copyAndNotify_1 :: Int -> Language -> T.Text
-copyAndNotify_1 (cyan . sformat int -> n) = \case
+copyAndNotify_1 (cyan . show -> n) = \case
     Japanese   -> "#[" <> n <>"]をコピー中・・・"
     Polish     -> "Kopiowanie #[" <> n <> "]"
     Croatian   -> "Kopiranje #[" <> n <> "]"
@@ -1177,7 +1176,7 @@ cleanCache_2 = \case
     _          -> "This will delete the ENTIRE package cache."
 
 cleanCache_3 :: Int -> Language -> T.Text
-cleanCache_3 (bt . sformat int -> n) = \case
+cleanCache_3 (bt . show -> n) = \case
     Japanese   -> "パッケージ・ファイルは" <> n <> "個保存される。"
     Polish     -> n <> " wersji każdego pakietu zostanie zachowane."
     Croatian   -> n <> " zadnjih verzija svakog paketa će biti zadržano."
@@ -1260,7 +1259,7 @@ cleanNotSaved_1 = \case
 
 -- NEEDS TRANSLATION
 cleanNotSaved_2 :: Int -> Language -> T.Text
-cleanNotSaved_2 (cyan . T.pack . show -> s) = \case
+cleanNotSaved_2 (cyan . show -> s) = \case
     Japanese   -> "「" <> s <> "」の不要パッケージファイルあり。削除？"
     Croatian   -> s <> " nepotrebnih datoteka pronađeno. Obrisati?"
     German     -> s <> " nicht benötigte Paketdateien gefunden. Löschen?"

--- a/src/Aura/Logo.hs
+++ b/src/Aura/Logo.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- Library for printing an animated AURA version message.
 
 {-
@@ -24,16 +23,16 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Logo where
 
+import BasicPrelude
+
 import Control.Concurrent (threadDelay)
 import System.IO          (stdout, hFlush)
-import Data.Monoid        ((<>))
 import Data.Foldable      (traverse_, fold)
 
 import Aura.Colour.Text (yellow)
 
 import Aura.Shell            (cursorUpLineCode)
 import qualified Data.Text as T
-import qualified Data.Text.IO as IO
 
 ---
 
@@ -68,23 +67,23 @@ pill = [ ""
 takeABite :: Int -> IO ()
 takeABite pad = drawMouth Closed *> drawMouth Open
     where drawMouth mouth = do
-            traverse_ IO.putStrLn $ renderPacmanHead pad mouth
+            traverse_ putStrLn $ renderPacmanHead pad mouth
             raiseCursorBy 4
             hFlush stdout
             threadDelay 125000
 
 drawPills :: Int -> IO ()
-drawPills numOfPills = traverse_ IO.putStrLn pills
+drawPills numOfPills = traverse_ putStrLn pills
     where pills = renderPills numOfPills
 
 raiseCursorBy :: Int -> IO ()
-raiseCursorBy = IO.putStr . raiseCursorBy'
+raiseCursorBy = putStr . raiseCursorBy'
 
 raiseCursorBy' :: Int -> T.Text
 raiseCursorBy' = cursorUpLineCode
 
 clearGrid :: IO ()
-clearGrid = IO.putStr blankLines *> raiseCursorBy 4
+clearGrid = putStr blankLines *> raiseCursorBy 4
     where blankLines = fold . replicate 4 . padString 23 $ "\n"
 
 renderPill :: Int -> [T.Text]

--- a/src/Aura/MakePkg.hs
+++ b/src/Aura/MakePkg.hs
@@ -29,10 +29,9 @@ module Aura.MakePkg
     , makepkgSource
     , makepkgConfFile ) where
 
-import           Data.Monoid
-import           Data.Text (Text)
+import           BasicPrelude hiding (FilePath)
+
 import qualified Data.Text as T
-import           Prelude hiding (FilePath)
 import           Shelly
 import           Text.Regex.PCRE ((=~))
 

--- a/src/Aura/Monad/Aura.hs
+++ b/src/Aura/Monad/Aura.hs
@@ -35,6 +35,8 @@ module Aura.Monad.Aura
     , asks
     ) where
 
+import BasicPrelude hiding (lift,catch,liftIO)
+
 import Data.OpenUnion.Imports
 import Control.Eff
 import Control.Eff.Exception

--- a/src/Aura/Packages/ABS.hs
+++ b/src/Aura/Packages/ABS.hs
@@ -42,13 +42,11 @@ module Aura.Packages.ABS
     , absSearchLookup
     ) where
 
-import           Control.Monad
-import           Data.List          (find)
+import           BasicPrelude  hiding    (FilePath, liftIO, (</>))
+
 import           Data.Foldable      (fold)
-import           Data.Set           (Set)
 import qualified Data.Set           as Set
 import qualified Data.Text          as T
-import           Data.Maybe         (isJust)
 import           Shelly   hiding    ((</>),find,liftIO)
 import           Filesystem.Path.CurrentOS
 import qualified Data.Text.ICU      as Re
@@ -66,7 +64,6 @@ import           Aura.Utils         (optionalPrompt)
 
 import           Utilities          (readFileUTF8, exists)
 import           Aura.Shell         (lsT', ls'')
-import           Prelude  hiding    (FilePath)
 
 ---
 

--- a/src/Aura/Packages/AUR.hs
+++ b/src/Aura/Packages/AUR.hs
@@ -32,11 +32,8 @@ module Aura.Packages.AUR
     , pkgUrl
     ) where
 
-import           Control.Monad        ((>=>), join)
-import           Data.Function        (on)
-import           Data.List            (sortBy)
-import           Data.Monoid          ((<>))
-import           Data.Maybe
+import           BasicPrelude hiding (FilePath, liftIO, (</>))
+
 import qualified Data.Text            as T
 import           Linux.Arch.Aur
 import           Filesystem.Path.CurrentOS      (FilePath,(</>),fromText)
@@ -48,7 +45,6 @@ import           Aura.Core
 
 import           Utilities            (decompress)
 import           Internet
-import           Prelude hiding (FilePath)
 
 ---
 

--- a/src/Aura/Packages/Repository.hs
+++ b/src/Aura/Packages/Repository.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-
 
 Copyright 2012, 2013, 2014 Colin Woodbury <colingw@gmail.com>
@@ -22,8 +21,8 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Packages.Repository ( pacmanRepo ) where
 
-import Data.Maybe
-import Data.Monoid
+import BasicPrelude
+
 import qualified Data.Text as T
 
 import Aura.Core

--- a/src/Aura/Pacman.hs
+++ b/src/Aura/Pacman.hs
@@ -26,12 +26,13 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Pacman where
 
+import BasicPrelude hiding (FilePath)
+
 import System.IO        (hFlush, stdout)
 import Control.Applicative (many)
 import Data.Attoparsec.Text
 import qualified Data.HashMap.Strict as M
 import Data.Ini
-import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
 import Aura.Cache
@@ -41,8 +42,6 @@ import Aura.Settings.Base (pacmanCmdOf)
 import Aura.Shell         (shellCmd, quietShellCmd, quietShellCmd')
 import Aura.Utils         (scoldAndFail)
 import Shelly hiding (cmd)
-import Prelude hiding (FilePath)
-
 import Utilities
 
 ---

--- a/src/Aura/Pkgbuild/Base.hs
+++ b/src/Aura/Pkgbuild/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-
 
 Copyright 2012, 2013, 2014 Colin Woodbury <colingw@gmail.com>
@@ -22,8 +21,8 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Pkgbuild.Base where
 
-import Control.Monad ((>=>))
-import Data.Monoid
+import BasicPrelude hiding (FilePath, (<.>), (</>), catch, liftIO)
+
 import qualified Data.Text as T
 
 import Aura.Bash
@@ -31,7 +30,6 @@ import Aura.Core
 import Aura.Monad.Aura
 import Aura.Pkgbuild.Editing
 import Filesystem.Path.CurrentOS
-import Prelude hiding (FilePath)
 
 ---
 

--- a/src/Aura/Pkgbuild/Editing.hs
+++ b/src/Aura/Pkgbuild/Editing.hs
@@ -25,6 +25,8 @@ module Aura.Pkgbuild.Editing
     ( hotEdit
     , customizepkg ) where
 
+import BasicPrelude hiding (FilePath, readFile, writeFile, liftIO, (</>))
+
 import Aura.Settings.Base
 import Aura.Monad.Aura
 import Aura.Languages
@@ -33,13 +35,11 @@ import Aura.Core
 
 import qualified Data.Text.Encoding as E
 
-import Control.Monad (void)
 import Utilities (openEditor, ifte_, ifFile, nothing, readFileUTF8)
 import Aura.Shell     (quietShellCmd, editor)
 import qualified Data.Text as T
 import Filesystem
 import Filesystem.Path.CurrentOS
-import Prelude hiding (FilePath, readFile, writeFile)
 
 ---
 

--- a/src/Aura/Pkgbuild/Records.hs
+++ b/src/Aura/Pkgbuild/Records.hs
@@ -23,6 +23,8 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Pkgbuild.Records where
 
+import BasicPrelude hiding (FilePath, writeFile, liftIO, (</>))
+
 import Shelly hiding (liftIO)
 import Data.Foldable    (traverse_)
 
@@ -34,7 +36,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
 
 import Utilities (readFileUTF8, exists)
-import Prelude hiding (FilePath,writeFile)
 import Filesystem
 
 ---

--- a/src/Aura/Settings/Base.hs
+++ b/src/Aura/Settings/Base.hs
@@ -23,9 +23,10 @@ module Aura.Settings.Base ( Settings(..)
                           , SortScheme(..)
                           , Truncation(..) ) where
 
+import BasicPrelude hiding (FilePath)
+
 import Aura.Languages (Language)
 
-import Prelude hiding (FilePath)
 import Shelly (FilePath)
 import qualified Data.Text as T
 

--- a/src/Aura/Settings/Enable.hs
+++ b/src/Aura/Settings/Enable.hs
@@ -24,8 +24,9 @@ module Aura.Settings.Enable
     ( getSettings
     , debugOutput ) where
 
+import BasicPrelude hiding (FilePath)
+
 import Data.Maybe         (fromJust)
-import Data.Monoid
 import Data.Foldable
 import qualified Data.Text as T
 import qualified Data.Text.IO as IO
@@ -39,7 +40,6 @@ import Aura.Flags
 import Utilities (ifte_, exists)
 import Aura.Shell
 import Shelly
-import Prelude hiding (FilePath)
 
 ---
 
@@ -54,7 +54,7 @@ getSettings lang' (auraFlags, input, pacOpts) = do
   language    <- checkLang lang'
   pure Settings { inputOf         = input
                 , pacOptsOf       = pacOpts
-                , otherOptsOf     = T.pack . show <$> auraFlags
+                , otherOptsOf     = show <$> auraFlags
                 , buildUserOf     = buildUser'
                 , langOf          = language
                 , pacmanCmdOf     = fromText pmanCommand
@@ -93,14 +93,14 @@ debugOutput ss = do
                         , "True User         => " <> trueuser
                         , "Build User        => " <> buildUserOf ss
                         , "Using Sudo?       => " <> yn sudop
-                        , "Pacman Flags      => " <> T.unwords (pacOptsOf ss)
-                        , "Other Flags       => " <> T.unwords (otherOptsOf ss)
-                        , "Other Input       => " <> T.unwords (inputOf ss)
-                        , "Language          => " <> T.pack (show (langOf ss))
+                        , "Pacman Flags      => " <> unwords (pacOptsOf ss)
+                        , "Other Flags       => " <> unwords (otherOptsOf ss)
+                        , "Other Input       => " <> unwords (inputOf ss)
+                        , "Language          => " <> show (langOf ss)
                         , "Pacman Command    => " <> toTextIgnore (pacmanCmdOf ss)
                         , "Editor            => " <> editorOf ss
                         , "$CARCH            => " <> carchOf ss
-                        , "Ignored Pkgs      => " <> T.unwords (ignoredPkgsOf ss)
+                        , "Ignored Pkgs      => " <> unwords (ignoredPkgsOf ss)
                         , "Build Path        => " <> toTextIgnore (buildPathOf ss)
                         , "Pkg Cache Path    => " <> toTextIgnore (cachePathOf ss)
                         , "Log File Path     => " <> toTextIgnore (logFilePathOf ss)

--- a/src/Aura/Shell.hs
+++ b/src/Aura/Shell.hs
@@ -1,16 +1,11 @@
-{-# LANGUAGE OverloadedStrings, Rank2Types, FlexibleContexts #-}
-
 module Aura.Shell where
 
-import Control.Applicative ((<|>))
-import Data.Maybe (fromMaybe, isJust, fromJust)
-import Data.Monoid ((<>))
-import Data.Text
+import BasicPrelude hiding (FilePath, (</>), putStr)
+
+import Data.Maybe (fromJust)
 import qualified Data.Text.IO as IO
-import Prelude hiding (FilePath)
 import Shelly
 import Aura.Monad.Aura (Aura,liftShelly)
-import Prelude hiding (FilePath,putStr)
 import Aura.Colour.Text (csi)
 
 ---

--- a/src/Aura/State.hs
+++ b/src/Aura/State.hs
@@ -29,17 +29,14 @@ module Aura.State
     , stateCache
     , getStateFiles ) where
 
-import qualified Data.Map.Lazy as M
+import BasicPrelude hiding (FilePath, writeFile, liftIO, (</>))
+
 
 import Shelly (FilePath, (</>), fromText, toTextIgnore)
 import Filesystem
-import Control.Monad   (unless)
-import Control.Arrow   (first)
-import Data.Maybe      (mapMaybe)
-import Data.List       (partition, sort)
-import Data.Monoid     ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
+import qualified Data.Map.Lazy as M
 
 import Aura.Cache
 import Aura.Colour.Text   (cyan, red)
@@ -54,7 +51,6 @@ import Aura.Utils.Numbers
 
 import Utilities (getSelection, readFileUTF8)
 import Aura.Shell     (lsT')
-import Prelude hiding (FilePath, writeFile)
 
 ---
 
@@ -106,8 +102,8 @@ getStateFiles = sort <$> liftShelly (lsT' stateCache)
 saveState :: Aura ()
 saveState = do
   state <- currentState
-  let filename = stateCache </> fromText (T.pack (dotFormat (timeOf state)))
-  liftIO $ writeFile filename $ E.encodeUtf8 $ T.pack (show state)
+  let filename = stateCache </> fromText (dotFormat (timeOf state))
+  liftIO $ writeFile filename $ E.encodeUtf8 $ show state
   notify saveState_1
 
 -- | Does its best to restore a state chosen by the user.
@@ -123,7 +119,7 @@ restoreState = ask >>= \ss -> do
   reinstallAndRemove (getFilename cache `mapMaybe` okay) remo
 
 readState :: FilePath -> Aura PkgState
-readState name = liftIO ((read . T.unpack) <$> readFileUTF8 (stateCache </> name))
+readState name = liftIO (read <$> readFileUTF8 (stateCache </> name))
 
 -- How does pacman do simultaneous removals and upgrades?
 -- I've seen it happen plenty of times.

--- a/src/Aura/Time.hs
+++ b/src/Aura/Time.hs
@@ -26,9 +26,10 @@ module Aura.Time
     , localTime
     , Time ) where
 
-import Data.List (intercalate)
+import BasicPrelude
+
 import Data.Time hiding (months)
-import Text.Printf (printf)
+import Text.Printf.TH (st)
 
 ---
 
@@ -39,7 +40,7 @@ data Time = Time { yearOf   :: Integer
                  , minuteOf :: Int }
             deriving (Eq, Show, Read)
 
-months :: [String]
+months :: [Text]
 months = [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"
          , "Oct", "Nov", "Dec" ]
 
@@ -55,10 +56,10 @@ toTime t = Time { yearOf   = ye
     where (ye, mo, da) = toGregorian $ localDay t
           (ho, mi)    = (todHour $ localTimeOfDay t, todMin $ localTimeOfDay t)
 
-dotFormat :: Time -> String
+dotFormat :: Time -> Text
 dotFormat t = intercalate "." items
     where items = [ show $ yearOf t
-                  , printf "%02d(%s)" (monthOf t) (months !! (monthOf t - 1))
-                  , printf "%02d" (dayOf t)
-                  , printf "%02d" (hourOf t)
-                  , printf "%02d" (minuteOf t) ]
+                  , [st|%02d(%s)|] (monthOf t) (months !! (monthOf t - 1))
+                  , [st|%02d|] (dayOf t)
+                  , [st|%02d|] (hourOf t)
+                  , [st|%02d|] (minuteOf t) ]

--- a/src/Aura/Utils.hs
+++ b/src/Aura/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- Utility functions specific to Aura
 
 {-
@@ -24,11 +23,10 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Utils where
 
+import BasicPrelude hiding (FilePath, span, liftIO, find, group)
+
 import Data.Text.ICU (regex, suffix, find, group, span)
 import System.IO                 (stdout, hFlush)
-import Data.List                 (sortBy)
-import Data.Monoid
-import Data.Maybe (fromMaybe, isJust)
 
 import Aura.Colour.Text
 import Aura.Languages (Language, whitespace, yesNoMessage, yesRegex)
@@ -36,11 +34,9 @@ import Aura.Monad.Aura
 import Aura.Settings.Base
 import Aura.Utils.Numbers
 
-import Prelude hiding (FilePath, span)
 import Shelly hiding (liftIO, find)
 import qualified Shelly
 import qualified Data.Text as T
-import qualified Data.Text.IO as IO
 
 ---
 
@@ -55,7 +51,7 @@ putStrLnA' colour s = putStrA' colour s <> "\n"
 
 -- Added `hFlush` here because some output appears to lag sometimes.
 putStrA :: Colouror -> T.Text -> Aura ()
-putStrA colour = liftIO . IO.putStr . putStrA' colour
+putStrA colour = liftIO . putStr . putStrA' colour
 --putStrA colour s = liftIO (putStr (putStrA' colour s) *> hFlush stdout)
 
 putStrA' :: Colouror -> T.Text -> T.Text
@@ -63,7 +59,7 @@ putStrA' colour s = "aura >>= " <> colour s
 
 printList :: Colouror -> Colouror -> T.Text -> [T.Text] -> Aura ()
 printList _ _ _ []        = pure ()
-printList tc ic msg items = liftIO . IO.putStrLn . printList' tc ic msg $ items
+printList tc ic msg items = liftIO . putStrLn . printList' tc ic msg $ items
 
 printList' :: Colouror -> Colouror -> T.Text -> [T.Text] -> T.Text
 printList' tc ic m is = putStrLnA' tc m `T.append` colouredItems
@@ -80,7 +76,7 @@ yesNoPrompt :: (Language -> T.Text) -> Aura Bool
 yesNoPrompt msg = asks langOf >>= \lang -> do
   putStrA yellow $ msg lang <> " " <> yesNoMessage lang <> " "
   liftIO $ hFlush stdout
-  response <- liftIO IO.getLine
+  response <- liftIO getLine
   pure $ isJust $ find (regex [] $ yesRegex lang) response
 
 -- | Doesn't prompt when `--noconfirm` is used.

--- a/src/Aura/Utils/Numbers.hs
+++ b/src/Aura/Utils/Numbers.hs
@@ -25,6 +25,8 @@ module Aura.Utils.Numbers
     ( Version(..)
     , version ) where
 
+import BasicPrelude
+
 import Text.Megaparsec
 import Text.Megaparsec.Text
 import Data.Foldable

--- a/src/Bash/Base.hs
+++ b/src/Bash/Base.hs
@@ -27,6 +27,7 @@ import qualified Data.Map.Lazy as M
 import Data.Either
 import Data.Foldable
 import qualified Data.Text as T
+import BasicPrelude
 
 ---
 
@@ -76,7 +77,7 @@ insert = M.insert
 -- but this one will only contain global variable names.
 toNamespace :: [Field] -> Namespace
 toNamespace [] = M.empty
-toNamespace (Variable n bs : fs) = insert n bs $ toNamespace fs
+toNamespace (Variable n bs : fs) = M.insert n bs $ toNamespace fs
 toNamespace (_:fs) = toNamespace fs
 
 -- | Never call this directly. Use `value` in `Aura/Bash`.

--- a/src/Bash/Parser.hs
+++ b/src/Bash/Parser.hs
@@ -29,11 +29,10 @@ module Bash.Parser ( parseBash ) where
 import Text.Megaparsec
 import Text.Megaparsec.Text
 
-import Control.Monad (void)
-import Data.Maybe          (catMaybes)
 import Data.Monoid
 import Data.Foldable
 import qualified Data.Text as T
+import BasicPrelude hiding (try)
 
 import Bash.Base
 
@@ -68,8 +67,8 @@ comment = Comment . T.pack <$> comment' <?> "valid comment"
 command :: Parser Field
 command = space *> (Command . T.pack <$> some commandChar <*> option [] (try args))
     where commandChar = alphaNumChar <|> oneOf "./"
-          args = char ' ' *> (unwords <$> line >>= \ls ->
-                   case parse (some single) "(command)" $ T.pack ls of
+          args = char ' ' *> (unwords . map T.pack <$> line >>= \ls ->
+                   case parse (some single) "(command)" $ ls of
                      Left _   -> fail "Failed parsing strings in a command"
                      Right bs -> pure $ fold bs)
           line = (:) <$> many (noneOf "\n\\") <*> next

--- a/src/Bash/Simplify.hs
+++ b/src/Bash/Simplify.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings#-}
 {-
 
   Simplify a parsed Bash script by replacing ${...} fields
@@ -43,9 +42,9 @@ module Bash.Simplify
 import Control.Monad.Trans.State.Lazy
 import Data.Foldable
 import qualified Data.Text as T
---import Text.Regex.PCRE ((=~))
 import qualified Data.Map.Lazy as M
 import Data.Monoid
+import BasicPrelude hiding (insert)
 
 import Bash.Base
 
@@ -99,7 +98,7 @@ getIndexedString' :: [BashString] -> T.Text -> State Namespace [T.Text]
 getIndexedString' (b:_) ""  = fromBashString <$> replaceStr b
 getIndexedString' bstrs "*" = foldMap fromBashString <$> traverse replaceStr bstrs
 getIndexedString' bstrs "@" = foldMap fromBashString <$> traverse replaceStr bstrs
-getIndexedString' bstrs num = fromBashString <$> replaceStr (bstrs !! read (T.unpack num))
+getIndexedString' bstrs num = fromBashString <$> replaceStr (bstrs !! read num)
 
 expandWrapper :: BashString -> State Namespace T.Text
 expandWrapper (SingleQ s) = pure s

--- a/src/Internet.hs
+++ b/src/Internet.hs
@@ -25,6 +25,8 @@ module Internet
     ( urlContents
     , saveUrlContents ) where
 
+import           BasicPrelude hiding (FilePath,(</>))
+
 import           Control.Lens
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as L
@@ -32,7 +34,6 @@ import           Network.Wreq
 import           Filesystem.Path.CurrentOS (FilePath, filename, (</>), fromText)
 import           Filesystem (openFile, IOMode(WriteMode))
 import           System.IO (hClose)
-import           Prelude hiding (FilePath)
 
 ---
 

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -24,26 +24,24 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Utilities where
 
-import Control.Eff         (SetMember,Eff)
-import Control.Eff.Lift    (Lift,lift)
-import Control.Concurrent  (threadDelay)
+import BasicPrelude hiding  (FilePath, readFile, find, lift)
+
+import Control.Eff          (SetMember,Eff)
+import Control.Eff.Lift     (Lift,lift)
+import Control.Concurrent   (threadDelay)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
 import qualified Data.Text.IO as IO
-import Data.Text.ICU       (regex ,find)
+import Data.Text.ICU        (regex ,find)
 import Data.Functor
-import Data.Monoid
-import Data.Maybe          (isJust)
-import Data.List           (dropWhileEnd)
 import Data.Foldable hiding (find)
-import Data.Char           (digitToInt)
-import System.IO hiding    (FilePath,openFile,readFile)
+import Data.Char            (digitToInt)
+import System.IO            (hFlush, stdout, hSetEncoding, hGetContents, TextEncoding)
 
 import Filesystem.Path.CurrentOS hiding (null)
 import qualified Filesystem.Path.CurrentOS as F
 import Filesystem
-import Shelly  hiding      (find)
-import Prelude hiding      (FilePath, readFile)
+import Shelly  hiding       (find)
 
 ---
 
@@ -145,8 +143,8 @@ getSelection :: [T.Text] -> IO T.Text
 getSelection [] = pure ""
 getSelection choiceLabels = do
   let quantity = length choiceLabels
-      valids   = (T.pack . show) <$> [1..quantity]
-      padding  = length . show $ quantity
+      valids   = show <$> [1..quantity]
+      padding  = T.length . show $ quantity
       choices  = zip valids choiceLabels
   traverse_ (\ (t,n) -> IO.putStrLn ((T.justifyLeft padding ' ' t) <> ". " <> n)) choices
   putStr ">> "
@@ -157,7 +155,7 @@ getSelection choiceLabels = do
     Nothing    -> getSelection choiceLabels  -- Ask again.
 
 -- | Print a list of Strings with a given interval in between.
-timedMessage :: Int -> [String] -> IO ()
+timedMessage :: Int -> [Text] -> IO ()
 timedMessage delay = traverse_ printMessage
     where printMessage msg = putStr msg *> hFlush stdout *> threadDelay delay
 

--- a/src/aura.hs
+++ b/src/aura.hs
@@ -29,12 +29,10 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 -}
 
-import System.Environment (getArgs)
-import Control.Monad      (when)
+import BasicPrelude hiding (catch, liftIO)
+
 import System.Exit        (exitSuccess, exitFailure)
-import Data.List          (nub, sort, intercalate)
 import Data.Foldable      (traverse_)
-import Data.Monoid        ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as IO
 import qualified Shelly as S
@@ -71,9 +69,10 @@ auraVersion = "1.4.0"
 main :: IO a
 main = getArgs >>= prepSettings . processFlags >>= execute >>= exit
 
-processFlags :: [String] -> (UserInput, Maybe Language)
-processFlags args = ((flags, nub input, pacOpts'), language)
-    where (language, _) = parseLanguageFlag args
+processFlags :: [Text] -> (UserInput, Maybe Language)
+processFlags args' = ((flags, nub input, pacOpts'), language)
+    where args = map T.unpack args'
+          (language, _) = parseLanguageFlag args
           (flags, input, pacOpts) = parseFlags language args
           pacOpts' = nub $ pacOpts <> reconvertFlags dualFlagMap flags
                    <> reconvertFlags pacmanFlagMap flags


### PR DESCRIPTION
This one is much simpler, just making the switch to basic-prelude and changing all of the `sformat`s to a more C-printf looking function. The reasoning of the Formatting to th-printf switch is simple: I did not see th-printf earlier, or I would have used it instead of Formatting from the beginning. My bad XD.

- [x] Prelude ==> BasicPrelude 
- [x] Formatting ==> th-printf