### PR TITLE
Suggested combined-search bash example change

### DIFF
--- a/doc/aura.8
+++ b/doc/aura.8
@@ -439,7 +439,7 @@ remove make deps, as well as show PKGBUILD diffs before building.
 use the following shell functions:
 .RS 4
 Bash => function search() {
-          aura -Ss $1 && aura -As $1
+          aura -Ss $1 || true && aura -As $1
         }
 
 Fish => function search


### PR DESCRIPTION
At least on my versions of bash (4.3.42) and aura (1.3.4), the suggested combined search function won't execute the AUR search if the main repository search doesn't yield anything. This change ensures both run and display relevant results, if any.
