### PR TITLE
fix curly brace extrapolations in dependencies

### DIFF
--- a/aura/src/Bash/Base.hs
+++ b/aura/src/Bash/Base.hs
@@ -86,7 +86,7 @@ getVar ns s = case M.lookup s ns of
 fromBashString :: BashString -> [String]
 fromBashString (SingleQ s) = [s]
 fromBashString (DoubleQ l) = [fold $ rights l]
-fromBashString (NoQuote l) = rights l
+fromBashString (NoQuote l) = [fold $ rights l]
 fromBashString (Backtic c) = ["`" <> unwords (fromCommand c) <> "`"]
 
 fromCommand :: Field -> [String]

--- a/aura/src/Bash/Parser.hs
+++ b/aura/src/Bash/Parser.hs
@@ -128,9 +128,10 @@ expansion = char '$' *> choice [ BashExpansion <$> base <*> indexer <* char '}'
 
 -- | Replaces ${...}. Strings can be extrapolated!
 unQuoted :: Parser [BashString]
-unQuoted = fmap NoQuote <$> many1 ( choice [ try $ (: []) . Left <$> expansion
-                                           , fmap Right <$> extrapolated []
-                                           ])
+unQuoted = fold <$> many1 ( choice [ try $ (: []) . singleton . Left <$> expansion
+                                   , fmap (singleton . Right) <$> extrapolated []
+                                   ])
+  where singleton = NoQuote . (: [])
 
 -- | Bash strings are extrapolated when they contain a brace pair
 -- with two or more substrings separated by commas within them.

--- a/aura/src/Bash/Simplify.hs
+++ b/aura/src/Bash/Simplify.hs
@@ -77,7 +77,7 @@ replace' somethingElse = pure somethingElse
 replaceStr :: BashString -> State Namespace BashString
 replaceStr s@(SingleQ _) = return s
 replaceStr (DoubleQ s)   = DoubleQ . fmap Right <$> expandStr s
-replaceStr (NoQuote s)   = DoubleQ . fmap Right <$> expandStr s
+replaceStr (NoQuote s)   = NoQuote . fmap Right <$> expandStr s
 replaceStr (Backtic f)   = Backtic <$> replace' f
 
 expandStr :: [Either BashExpansion String] -> State Namespace [String]


### PR DESCRIPTION
Fixes #430.

There are a few inconsistencies in the way bash strings are parsed that
make aura unable to correctly compile some AUR packages. A simple
example is the input:

    depends=(perl-{json,datetime})

is parsed as:

    ["perl-jsonperl-datetime"]

instead of:

    ["perl-json", "perl-datetime"]

This change puts in a few tweaks to fix this bug with extrapolation and
makes the bash parsing more consistent.

The first issue is that `DoubleQ` and `NoQuote` are `BashString`
constructors that contain a list of strings; however, it's not clear
what that list represents. The `unQuoted` parser treats the list of
strings as individual words, as `{foo,bar}` will be parsed as

    NoQuote [Right "foo", Right "bar"]

However, `doubleQuoted` parses expansions in the same way but later
concatenates them. So `"dep-${vers}"` will be parsed as

    DoubleQ [Right "dep-", Left (BashExpansion ...)]

Note that in the `NoQuote` example, you would expect a single string
with two words separated by a space, but in the `DoubleQ` example, you
would expect a single string with no spaces.

In a4bb0484b1, the change was made so that the list inside a `DoubleQ`
was concatenated as a singleton array, and I think this behavior makes
the most sense, since you can't represent variable interpolation if the
list represents individual words instead of fragments of a string. And
so, we must do the same when putting together `NoQuote`, too. This
effectively means that `{foo,bar}` will now produce `["foobar"]`, but we
can adjust the extrapolation behavior to accommodate for that.

There is also a strange behavior in `replaceStr`, where `NoQuote`
strings are turned into `DoubleQ` strings. As far as I can tell, this is
a mistake introduced in 95383612c9.

The last hurdle we must tackle is what `unQuoted` returns. In the case
of `{foo,bar}`, given our new understanding of what `NoQuote [...]`
means, we should be returning

    [NoQuote [Right "foo"], NoQuote [Right "bar"]]

We do this by pushing the `NoQuote` construction into the individual
parsers. This does however bring up an interesting point: the assignment
`depends=dep-${ver}` (without double quotes) will parse as an array of
two items. This was actually always the case given the way
`fromBashString` worked, so we're not introducing broken behavior. There
is more work that needs to be done on `unQuoted`, and perhaps some tests
would be extremely impactful.