### PR TITLE
allow more flexible locale parsing

### DIFF
--- a/aura/src/Aura/Languages.hs
+++ b/aura/src/Aura/Languages.hs
@@ -41,6 +41,7 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Aura.Languages where
 
+import           Control.Arrow
 import qualified Data.Map.Lazy as Map (Map, (!), fromList, toList, mapWithKey)
 import           Data.Monoid
 
@@ -134,8 +135,8 @@ whitespace :: Language -> String
 whitespace Japanese = "　"  -- \12288
 whitespace _ = " "          -- \32
 
-langFromEnv :: String -> Language
-langFromEnv = \case
+langFromLocale :: String -> Language
+langFromLocale = take 2 >>> \case
     "ja" -> Japanese
     "pl" -> Polish
     "hr" -> Croatian

--- a/aura/src/Aura/Settings/Enable.hs
+++ b/aura/src/Aura/Settings/Enable.hs
@@ -32,7 +32,7 @@ import System.Directory (doesDirectoryExist)
 import System.Environment (getEnvironment)
 
 import Aura.Flags
-import Aura.Languages (Language, langFromEnv)
+import Aura.Languages (Language, langFromLocale)
 import Aura.MakePkg (makepkgConfFile)
 import Aura.Pacman
 import Aura.Settings.Base
@@ -116,7 +116,7 @@ debugOutput ss = do
                      , "Keep source?      => " <> yn (keepSource ss) ]
 
 checkLang :: Maybe Language -> Environment -> Language
-checkLang Nothing env   = langFromEnv $ getLangVar env
+checkLang Nothing env   = langFromLocale $ getLocale env
 checkLang (Just lang) _ = lang
 
 -- | Defaults to the cache path if no (legal) build path was given.

--- a/aura/src/Shell.hs
+++ b/aura/src/Shell.hs
@@ -37,6 +37,7 @@ import Control.Exception (catchJust)
 import System.FilePath   ((</>))
 import System.Process    (readProcess, readProcessWithExitCode, rawSystem)
 import Control.Monad     (void)
+import Data.Foldable
 import Data.Maybe        (fromMaybe, fromJust)
 import Data.Monoid
 import Data.List         (intercalate)
@@ -183,6 +184,7 @@ getTrueUser env | isTrueRoot env  = "root"
 getEditor :: Environment -> String
 getEditor env = fromMaybe "vi" $ getEnvVar "EDITOR" env
 
--- This will get the LANG variable from the environment
-getLangVar :: Environment -> String
-getLangVar env = fromMaybe "C" $ getEnvVar "LANG" env
+-- This will get the locale variable for translations from the environment
+getLocale :: Environment -> String
+getLocale env = fromMaybe "C" . asum . fmap (`getEnvVar` env)
+    $ ["LC_ALL", "LC_MESSAGES", "LANG"]


### PR DESCRIPTION
This improves aura's use of system locale detection and utilization.
First, instead of just reading from `LANG`, we are mimicking
`SETLOCALE(3)` to query the `LC_MESSAGES` category, which is used for
translations. This means we first prefer `LC_ALL` (used for debugging
purposes), then `LC_MESSAGES`, and then `LANG`. It is worth noting that
`pacman` uses this same logic for displaying its translated messages.
Some functions have been renamed to make this more clear. It is worth
noting that there _is_ a `setlocale` package for Haskell that acts as a
binding to the C function, but doing it manually seems to fit into
Aura's use of the pure `Environment` map more cleanly.

The other issue is that the `Languages` module was only matching exact
character codes for different languages. This is problematic, since
locales are of the format `language[_territory][.codeset][@modifier]`,
for example, `de_DE.UTF-8`. What we really want to do is only examine
the language portion of this locale code and match it against the
support map. We could parse the whole locale, but it doesn't seem like a
very necessary step at this point in time.