### PR TITLE
Fixing `-B`

### DIFF
--- a/aura/README.md
+++ b/aura/README.md
@@ -162,7 +162,7 @@ Search the package cache for package files via a regex:
 
 Backup the package cache:
 
-    aura -Cb (/path/to/backup/location/)
+    aura -C --backup (/path/to/backup/location/)
 
 Reduce the package cache to contain only 'x' of each package file:
 

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -208,7 +208,7 @@ Saves a given number of the most recently saved package states and removes the
 rest.
 .RE
 .P
-\fB\-r\fR, \-\-restore
+\fB\-\-restore\fR
 .RS 4
 Restores a record kept with \fI\-B\fR. Attempts to downgrade any packages that
 were upgraded since the chosen save. Will remove any that weren't installed at
@@ -217,7 +217,7 @@ the time.
 
 .SH DOWNGRADE OPTIONS (\fI\-C\fR)
 .P
-\fB\-b\fR, \-\-backup <path>
+\fB\-\-backup\fR <path>
 .RS 4
 Backup the package cache to a given directory. The given directory must already
 exist. During copying, progress will be shown. If the copy takes too long, you

--- a/aura/doc/source/changelog.rst
+++ b/aura/doc/source/changelog.rst
@@ -1,5 +1,11 @@
 Aura Changelog
 ==============
+1.3.8
+-----
+- Fixed behaviour of `-B` flags. For restoring of saved states, use the long
+  form: `aura -B --restore`. Cache backups also need to take their long form: `aura -C --backup`.
+- Fixed handling of language flags. Thanks to Doug Patti!
+
 1.3.5
 -----
 - Aura now uses version 5 of the `aur` package, to fix a critial bug
@@ -402,7 +408,7 @@ Aura Changelog
 0.8.0.0
 -------
 - Help message now supports multiple languages.
-- Broke "no overlapping options" convention. 
+- Broke "no overlapping options" convention.
 - `-Cz` is now `-Cb`.
 - New option `-Ad`. Lists _all_ dependencies of an AUR package.
   This is to aid pre-building research.

--- a/aura/src/Aura/Commands/B.hs
+++ b/aura/src/Aura/Commands/B.hs
@@ -1,6 +1,6 @@
 {-
 
-Copyright 2012, 2013, 2014 Colin Woodbury <colingw@gmail.com>
+Copyright 2012 - 2017 Colin Woodbury <colingw@gmail.com>
 
 This file is part of Aura.
 
@@ -24,15 +24,15 @@ module Aura.Commands.B
     , restoreState
     , cleanStates ) where
 
+import Data.Char (isDigit)
+import Data.Foldable (traverse_)
 import System.FilePath ((</>))
-import Data.Char       (isDigit)
-import Data.Foldable   (traverse_)
 
-import Aura.Utils (scoldAndFail, optionalPrompt)
-import Aura.Core  (warn)
-import Aura.Monad.Aura
+import Aura.Core (warn)
 import Aura.Languages
+import Aura.Monad.Aura
 import Aura.State
+import Aura.Utils (scoldAndFail, optionalPrompt)
 
 import Shell (rm)
 

--- a/aura/src/Aura/Flags.hs
+++ b/aura/src/Aura/Flags.hs
@@ -155,7 +155,7 @@ auraOptions = Option [] ["aurignore"] (ReqArg AURIgnore "" ) "" :
               Option [] ["tail"] (OptArg (TruncTail . truncHandler) "") "" :
               fmap simpleOption
               [ ( "a", ["delmakedeps"],  DelMDeps      )
-              , ( "b", ["backup"],       CacheBackup   )
+              , ( [],  ["backup"],       CacheBackup   )
               , ( "c", ["clean"],        Clean         )
               , ( "d", ["deps"],         ViewDeps      )
               , ( "j", ["abandon"],      Abandon       )
@@ -163,7 +163,7 @@ auraOptions = Option [] ["aurignore"] (ReqArg AURIgnore "" ) "" :
               , ( "i", ["info"],         Info          )
               , ( "p", ["pkgbuild"],     GetPkgbuild   )
               , ( "q", ["quiet"],        Quiet         )
-              , ( "r", ["restore"],      RestoreState  )
+              , ( [],  ["restore"],      RestoreState  )
               , ( "s", ["search"],       Search        )
               , ( "t", ["treesync"],     TreeSync      )
               , ( "u", ["sysupgrade"],   Upgrade       )

--- a/aura/src/Aura/Languages.hs
+++ b/aura/src/Aura/Languages.hs
@@ -1705,6 +1705,11 @@ restoreState_1 = \case
     Indonesia  -> "Versi yang diturunkan tidak tersedia untuk: "
     _          -> "Requested downgrade versions not available for:"
 
+restoreState_2 :: Language -> String
+restoreState_2 = \case
+  Japanese -> "保存されたパッケージ状態がない。作るには「-B」を。"
+  _        -> "No saved states to be restored. (Use -B to save the current state)"
+
 -- NEEDS TRANSLATION
 reinstallAndRemove_1 :: Language -> String
 reinstallAndRemove_1 = \case

--- a/aura/src/Aura/Time.hs
+++ b/aura/src/Aura/Time.hs
@@ -36,7 +36,8 @@ data Time = Time { yearOf   :: Integer
                  , monthOf  :: Int
                  , dayOf    :: Int
                  , hourOf   :: Int
-                 , minuteOf :: Int }
+                 , minuteOf :: Int
+                 , secondOf :: Int }
             deriving (Eq, Show, Read)
 
 months :: [String]
@@ -50,10 +51,10 @@ toTime :: LocalTime -> Time
 toTime t = Time { yearOf   = ye
                 , monthOf  = mo
                 , dayOf    = da
-                , hourOf   = ho
-                , minuteOf = mi }
+                , hourOf   = todHour $ localTimeOfDay t
+                , minuteOf = todMin $ localTimeOfDay t
+                , secondOf = round . todSec $ localTimeOfDay t }
     where (ye, mo, da) = toGregorian $ localDay t
-          (ho, mi)    = (todHour $ localTimeOfDay t, todMin $ localTimeOfDay t)
 
 dotFormat :: Time -> String
 dotFormat t = intercalate "." items
@@ -61,4 +62,5 @@ dotFormat t = intercalate "." items
                   , printf "%02d(%s)" (monthOf t) (months !! (monthOf t - 1))
                   , printf "%02d" (dayOf t)
                   , printf "%02d" (hourOf t)
-                  , printf "%02d" (minuteOf t) ]
+                  , printf "%02d" (minuteOf t)
+                  , printf "%02d" (secondOf t) ]

--- a/aura/src/aura.hs
+++ b/aura/src/aura.hs
@@ -1,6 +1,6 @@
 {-
 
-Copyright 2012 - 2016 Colin Woodbury <colingw@gmail.com>
+Copyright 2012 - 2017 Colin Woodbury <colingw@gmail.com>
 
 This file is part of Aura.
 


### PR DESCRIPTION
There were some oversights in how `-B` flags are handled. Critically, this PR removes `-r` and `-b` (for `-C`) as subflags, as there was some unresolvable conflicts with underlying pacman flags. Their long forms can be used instead, and the man page has been changed to reflect that.