### PR TITLE
feature: Simple SrcInfo Parser

### DIFF
--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -93,6 +93,7 @@ executable aura
                      , Bash.Base
                      , Bash.Parser
                      , Bash.Simplify
+                     , SrcInfoParser
 
   build-depends:       aur>=5
                      , array
@@ -121,3 +122,20 @@ executable aura
                      , unix
                      , unordered-containers
                      , wreq
+
+test-suite tests
+  type:              exitcode-stdio-1.0
+
+  build-depends:     base
+                     , tasty >= 0.11 && < 0.12
+                     , tasty-hunit >= 0.9.2 && < 0.10
+                     , text
+                     , megaparsec
+                     , basic-prelude
+
+  main-is:           Main.hs
+  hs-source-dirs:    tests
+                     , src
+  default-language:  Haskell2010
+  other-modules:     SrcInfoParser
+                     , SrcInfoParserTest

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -94,6 +94,7 @@ executable aura
                      , Bash.Parser
                      , Bash.Simplify
                      , SrcInfoParser
+                     , SrcInfoType
 
   build-depends:       aur>=5
                      , array
@@ -139,3 +140,4 @@ test-suite tests
   default-language:  Haskell2010
   other-modules:     SrcInfoParser
                      , SrcInfoParserTest
+                     , SrcInfoType

--- a/aura/src/SrcInfoParser.hs
+++ b/aura/src/SrcInfoParser.hs
@@ -1,71 +1,52 @@
+{-
+
+Copyright 2017 Jiehong Ma <email@majiehong.com>
+
+This file is part of Aura.
+
+Aura is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Aura is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Aura.  If not, see <http://www.gnu.org/licenses/>.
+
+-}
+
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module SrcInfoParser (srcInfoData,
-                      SrcInfo(..),
-                      lineParser,
+module SrcInfoParser (lineParser,
                       Line(..),
                       parseConfig,
                       parseSingleLine,
                       combineJustList,
                       add,
                       merge) where
-
 import Data.Text
 import Data.Int
 import Data.Eq
-import Data.Maybe
-import Data.Functor
-import Text.Megaparsec
-import Text.Megaparsec.String
 import Data.String
 import Data.List
+import Data.Maybe
+import Data.Functor
+import Data.Functor.Identity
+import Text.Megaparsec
+import Text.Megaparsec.String
 import qualified Text.Megaparsec.Lexer as L
 import BasicPrelude
 import Prelude
-
-data SrcInfo = SrcInfo { name        :: Maybe Text
-                       , version     :: Maybe Text
-                       , release     :: Maybe Int
-                       , epoch       :: Maybe Text
-                       , arch        :: Maybe [Text]
-                       , licenses    :: Maybe [Text]
-                       , makeDepends :: Maybe [Text]
-                       , provides    :: Maybe [Text]
-                       , conflicts   :: Maybe [Text]
-                       , sources     :: Maybe [Text]
-                       , md5sums     :: Maybe [Text]
-                       , sha1sums    :: Maybe [Text]
-                       , sha224sums  :: Maybe [Text]
-                       , sha256sums  :: Maybe [Text]
-                       , sha384sums  :: Maybe [Text]
-                       , sha512sums  :: Maybe [Text]
-                       } deriving (Eq, Show)
-
-srcInfoData :: SrcInfo
-srcInfoData = SrcInfo { name        = Nothing
-                      , version     = Nothing
-                      , release     = Nothing
-                      , epoch       = Nothing
-                      , arch        = Nothing
-                      , licenses    = Nothing
-                      , makeDepends = Nothing
-                      , provides    = Nothing
-                      , conflicts   = Nothing
-                      , sources     = Nothing
-                      , md5sums     = Nothing
-                      , sha1sums    = Nothing
-                      , sha224sums  = Nothing
-                      , sha256sums  = Nothing
-                      , sha384sums  = Nothing
-                      , sha512sums  = Nothing
-                      }
+import SrcInfoType
 
 data Line = Line { parameter :: String
                  , value     :: String
                  } deriving (Eq, Show)
-
-type Lines = [Line]
 
 skip :: Parser ()
 skip = L.space (void spaceChar) commentLine commentLine
@@ -145,9 +126,6 @@ combineJustList a b =
 
 merge :: [SrcInfo] -> SrcInfo
 merge = BasicPrelude.foldl add srcInfoData
-
-removeEmptyLines :: Line -> Bool
-removeEmptyLines line = parameter line /= ""
 
 parseConfig :: String -> SrcInfo
 parseConfig input = do

--- a/aura/src/SrcInfoParser.hs
+++ b/aura/src/SrcInfoParser.hs
@@ -1,0 +1,157 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module SrcInfoParser (srcInfoData,
+                      SrcInfo(..),
+                      lineParser,
+                      Line(..),
+                      parseConfig,
+                      parseSingleLine,
+                      combineJustList,
+                      add,
+                      merge) where
+
+import Data.Text
+import Data.Int
+import Data.Eq
+import Data.Maybe
+import Data.Functor
+import Text.Megaparsec
+import Text.Megaparsec.String
+import Data.String
+import Data.List
+import qualified Text.Megaparsec.Lexer as L
+import BasicPrelude
+import Prelude
+
+data SrcInfo = SrcInfo { name        :: Maybe Text
+                       , version     :: Maybe Text
+                       , release     :: Maybe Int
+                       , epoch       :: Maybe Text
+                       , arch        :: Maybe [Text]
+                       , licenses    :: Maybe [Text]
+                       , makeDepends :: Maybe [Text]
+                       , provides    :: Maybe [Text]
+                       , conflicts   :: Maybe [Text]
+                       , sources     :: Maybe [Text]
+                       , md5sums     :: Maybe [Text]
+                       , sha1sums    :: Maybe [Text]
+                       , sha224sums  :: Maybe [Text]
+                       , sha256sums  :: Maybe [Text]
+                       , sha384sums  :: Maybe [Text]
+                       , sha512sums  :: Maybe [Text]
+                       } deriving (Eq, Show)
+
+srcInfoData :: SrcInfo
+srcInfoData = SrcInfo { name        = Nothing
+                      , version     = Nothing
+                      , release     = Nothing
+                      , epoch       = Nothing
+                      , arch        = Nothing
+                      , licenses    = Nothing
+                      , makeDepends = Nothing
+                      , provides    = Nothing
+                      , conflicts   = Nothing
+                      , sources     = Nothing
+                      , md5sums     = Nothing
+                      , sha1sums    = Nothing
+                      , sha224sums  = Nothing
+                      , sha256sums  = Nothing
+                      , sha384sums  = Nothing
+                      , sha512sums  = Nothing
+                      }
+
+data Line = Line { parameter :: String
+                 , value     :: String
+                 } deriving (Eq, Show)
+
+type Lines = [Line]
+
+skip :: Parser ()
+skip = L.space (void spaceChar) commentLine commentLine
+  where commentLine  = L.skipLineComment "#"
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme skip
+
+rightValue = some (alphaNumChar <|> char '>' <|> char '.' <|> char '=' <|> char '<' <|> char '/' <|> char '#' <|> char '-' <|> char '+' <|> char ':' <|> char '_')
+
+lineParser :: Parser Line
+lineParser = do
+  _ <- lexeme (many (char ' ' <|> char '\t'))
+  name <- lexeme (some alphaNumChar)
+  _ <- char '='
+  _ <- many (char ' ')
+  value <- lexeme rightValue
+  return Line {parameter = name, value = value}
+
+parseSingleLine :: String -> Line
+parseSingleLine x = do
+  let parsed = parseMaybe lineParser x
+  Data.Maybe.fromMaybe (Line "" "") parsed
+
+convertLineToSrcInfo :: Line -> SrcInfo
+convertLineToSrcInfo l =
+  case parameter l of
+    "pkgbase" -> srcInfoData { name = Just (pack (value l))}
+    "pkgver" -> srcInfoData { version = Just (pack (value l))}
+    "pkgrel" -> srcInfoData { release = Just (Prelude.read (value l) :: Int)}
+    "epoch" -> srcInfoData { epoch = Just (pack (value l))}
+    "arch" -> srcInfoData {arch = Just [pack (value l)]}
+    "license" -> srcInfoData {licenses = Just [pack (value l)]}
+    "makedepends" -> srcInfoData {makeDepends = Just [pack (value l)]}
+    "provides" -> srcInfoData {provides = Just [pack (value l)]}
+    "conflicts" -> srcInfoData {conflicts = Just [pack (value l)]}
+    "source" -> srcInfoData {sources = Just [pack (value l)]}
+    "md5sums" -> srcInfoData {md5sums = Just [pack (value l)]}
+    "sha1sums" -> srcInfoData {sha1sums = Just [pack (value l)]}
+    "sha224sums" -> srcInfoData {sha224sums = Just [pack (value l)]}
+    "sha256sums" -> srcInfoData {sha256sums = Just [pack (value l)]}
+    "sha384sums" -> srcInfoData {sha384sums = Just [pack (value l)]}
+    "sha512sums" -> srcInfoData {sha512sums = Just [pack (value l)]}
+    _ -> srcInfoData
+
+-- Only add them together if 1 side contains Nothing
+add :: SrcInfo -> SrcInfo -> SrcInfo
+add x y = x { name = value (name x) (name y)
+            , version = value (version x) (version y)
+            , release = value (release x) (release y)
+            , epoch = value (epoch x) (epoch y)
+            , arch = combineJustList (arch x) (arch y)
+            , licenses = combineJustList (licenses x) (licenses y)
+            , makeDepends = combineJustList (makeDepends x) (makeDepends y)
+            , provides = combineJustList (provides x) (provides y)
+            , conflicts = combineJustList (conflicts x) (conflicts y)
+            , sources = combineJustList (sources x) (sources y)
+            , md5sums = combineJustList (md5sums x) (md5sums y)
+            , sha1sums = combineJustList (sha1sums x) (sha1sums y)
+            , sha224sums = combineJustList (sha224sums x) (sha224sums y)
+            , sha256sums = combineJustList (sha256sums x) (sha256sums y)
+            , sha384sums = combineJustList (sha384sums x) (sha384sums y)
+            , sha512sums = combineJustList (sha512sums x) (sha512sums y)
+            }
+  where value a b =
+          case a of
+            Just v -> Just v
+            Nothing -> b
+
+combineJustList :: Maybe [Text] -> Maybe [Text] -> Maybe [Text]
+combineJustList a b =
+  case a of
+    Nothing -> b
+    Just k -> case b of
+      Nothing -> Just k
+      Just l -> Just (k Data.List.++ l)
+
+merge :: [SrcInfo] -> SrcInfo
+merge = BasicPrelude.foldl add srcInfoData
+
+removeEmptyLines :: Line -> Bool
+removeEmptyLines line = parameter line /= ""
+
+parseConfig :: String -> SrcInfo
+parseConfig input = do
+  let rawLines = Prelude.map parseSingleLine (Data.String.lines input)
+  -- let lines = BasicPrelude.filter removeEmptyLines rawLines
+  let partialConfig = Prelude.map convertLineToSrcInfo rawLines
+  merge partialConfig

--- a/aura/src/SrcInfoType.hs
+++ b/aura/src/SrcInfoType.hs
@@ -1,0 +1,66 @@
+{-
+
+Copyright 2017 Jiehong Ma <email@majiehong.com>
+
+This file is part of Aura.
+
+Aura is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Aura is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Aura.  If not, see <http://www.gnu.org/licenses/>.
+
+-}
+
+module SrcInfoType (SrcInfo(..), srcInfoData) where
+
+import Data.Text
+import Data.Int
+import Data.Eq
+import Data.Maybe
+import BasicPrelude
+
+
+data SrcInfo = SrcInfo { name        :: Maybe Text
+                       , version     :: Maybe Text
+                       , release     :: Maybe Int
+                       , epoch       :: Maybe Text
+                       , arch        :: Maybe [Text]
+                       , licenses    :: Maybe [Text]
+                       , makeDepends :: Maybe [Text]
+                       , provides    :: Maybe [Text]
+                       , conflicts   :: Maybe [Text]
+                       , sources     :: Maybe [Text]
+                       , md5sums     :: Maybe [Text]
+                       , sha1sums    :: Maybe [Text]
+                       , sha224sums  :: Maybe [Text]
+                       , sha256sums  :: Maybe [Text]
+                       , sha384sums  :: Maybe [Text]
+                       , sha512sums  :: Maybe [Text]
+                       } deriving (Eq, Show)
+
+srcInfoData :: SrcInfo
+srcInfoData = SrcInfo { name        = Nothing
+                      , version     = Nothing
+                      , release     = Nothing
+                      , epoch       = Nothing
+                      , arch        = Nothing
+                      , licenses    = Nothing
+                      , makeDepends = Nothing
+                      , provides    = Nothing
+                      , conflicts   = Nothing
+                      , sources     = Nothing
+                      , md5sums     = Nothing
+                      , sha1sums    = Nothing
+                      , sha224sums  = Nothing
+                      , sha256sums  = Nothing
+                      , sha384sums  = Nothing
+                      , sha512sums  = Nothing
+                      }

--- a/aura/tests/Main.hs
+++ b/aura/tests/Main.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Test.Tasty
+import SrcInfoParserTest
+
+suite :: TestTree
+suite = testGroup "Aura Tests" [unitTests]
+
+unitTests :: TestTree
+unitTests = testGroup "Unit Tests" [SrcInfoParserTest.tests]
+
+main :: IO ()
+main = defaultMain suite

--- a/aura/tests/SrcInfoParserTest.hs
+++ b/aura/tests/SrcInfoParserTest.hs
@@ -1,0 +1,205 @@
+module SrcInfoParserTest where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.String
+import Data.List
+import Data.Text
+import SrcInfoParser
+import Prelude
+
+tests :: TestTree
+tests = testGroup "Src Info Parser"
+  [ testCase "Line No Space" lineNoSpace
+  , testCase "Line With Space" lineSpace
+  , testCase "Line With Version =" lineVersionEqual
+  , testCase "Line With Version >=" lineVersionGreaterThan
+  , testCase "Line With Version <" lineVersionLowerThan
+  , testCase "Line With Arch" lineArch
+  , testCase "Line With Arch x64" lineArchSixtyFour
+  , testCase "Line With URL" lineUrl
+  , testCase "Line With CheckSum" lineCheckSum
+  , testCase "Multiple Lines" multipleLine
+  , testCase "Combine Empty Maybe" combineJustListEmpty
+  , testCase "Combine Left Empty Line" combineJustListLeftEmpty
+  , testCase "Combine Right Empty Line" combineJustListRightEmpty
+  , testCase "Combine Full Line" combineJustListFull
+  , testCase "Add 2 empty SrcInfo" addNothing
+  , testCase "Add 1 empty SrcInfo" addOneNothing
+  , testCase "Add 2 SrcInfo" addTwoSrcInfo
+  , testCase "Merge [SrcInfo]" mergeSrcInfo
+  , testCase "Nominal Example" nominalExample
+  ]
+
+lineNoSpace :: Assertion
+lineNoSpace = do
+  let expected = Line {parameter = "name", value = "value"}
+  let lineToParse = fromString (parameter expected ++ "=" ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineSpace :: Assertion
+lineSpace = do
+  let expected = Line {parameter = "name", value = "value"}
+  let lineToParse = fromString (" " ++ parameter expected ++ " = " ++ value expected ++ "  ")
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineVersionEqual :: Assertion
+lineVersionEqual = do
+  let expected = Line {parameter = "name", value = "value=2.3"}
+  let lineToParse = fromString (" " ++ parameter expected ++ "=" ++ value expected ++ "  ")
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineVersionGreaterThan :: Assertion
+lineVersionGreaterThan = do
+  let expected = Line {parameter = "name", value = "value>=2.3"}
+  let lineToParse = fromString (" " ++ parameter expected ++ "=" ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineVersionLowerThan :: Assertion
+lineVersionLowerThan = do
+  let expected = Line {parameter = "name", value = "value<2.3"}
+  let lineToParse = fromString (" " ++ parameter expected ++ "=" ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineArch :: Assertion
+lineArch = do
+  let expected = Line {parameter = "arch", value = "i686"}
+  let lineToParse = fromString ("\t" ++ parameter expected ++ " = " ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineArchSixtyFour :: Assertion
+lineArchSixtyFour = do
+  let expected = Line {parameter = "arch", value = "x86_64"}
+  let lineToParse = fromString ("\t" ++ parameter expected ++ " = " ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineUrl :: Assertion
+lineUrl = do
+  let expected = Line {parameter = "source", value = "git+https://github.com/user/project.git#tag=name-0.35"}
+  let lineToParse = fromString (" " ++ parameter expected ++ "=" ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+lineCheckSum :: Assertion
+lineCheckSum = do
+  let expected = Line {parameter = "sha512sums", value = "fb50ba9f6d5ea8aa81be8f1823040a175809e844e44262"}
+  let lineToParse = fromString (" " ++ parameter expected ++ "=" ++ value expected)
+  let actual = parseSingleLine lineToParse
+  assertEqual "" expected actual
+
+multipleLine :: Assertion
+multipleLine = do
+  let expected = [ Line {parameter = "sha512sums", value = "fb50ba9f6d5ea8aa81be8f1823040a175809e844e44262"}
+                 , Line {parameter = "name", value = "val"}]
+  let linesToParse = Data.String.lines (" " ++ parameter (Data.List.head expected) ++ "=" ++ value (Data.List.head expected)
+                            ++ "\n" ++ parameter (expected !! 1) ++ "=" ++ value (expected !! 1))
+  let actual = Prelude.map parseSingleLine linesToParse
+  assertEqual "" expected actual
+
+combineJustListEmpty :: Assertion
+combineJustListEmpty = do
+  let actual = combineJustList Nothing Nothing
+  assertEqual "" Nothing actual
+
+combineJustListLeftEmpty :: Assertion
+combineJustListLeftEmpty = do
+  let expected = Just [pack "a", pack "b"]
+  let actual = combineJustList Nothing expected
+  assertEqual "" expected actual
+
+combineJustListRightEmpty :: Assertion
+combineJustListRightEmpty = do
+  let expected = Just [pack "a", pack "b"]
+  let actual = combineJustList expected Nothing
+  assertEqual "" expected actual
+
+combineJustListFull :: Assertion
+combineJustListFull = do
+  let expected = Just [pack "a", pack "b", pack "c", pack "d"]
+  let actual = combineJustList (Just [pack "a", pack "b"]) (Just [pack "c", pack "d"])
+  assertEqual "" expected actual
+
+addNothing :: Assertion
+addNothing = do
+  let expected = srcInfoData
+  let actual = add srcInfoData srcInfoData
+  assertEqual "" expected actual
+
+addOneNothing :: Assertion
+addOneNothing = do
+  let expected = srcInfoData {arch = Just [pack "one"]}
+  let actual = add srcInfoData srcInfoData {arch = Just [pack "one"]}
+  assertEqual "" expected actual
+
+addTwoSrcInfo :: Assertion
+addTwoSrcInfo = do
+  let expected = srcInfoData {arch = Just [pack "one", pack "middle", pack "two"]}
+  let actual = add srcInfoData {arch = Just [pack "one", pack "middle"]} srcInfoData {arch = Just [pack "two"]}
+  assertEqual "" expected actual
+
+mergeSrcInfo :: Assertion
+mergeSrcInfo = do
+  let expected = srcInfoData {arch = Just [pack "one", pack "middle", pack "two"]}
+  let actual = merge [srcInfoData {arch = Just [pack "one"]}, srcInfoData {arch = Just [pack "middle"]}, srcInfoData {arch = Just [pack "two"]}]
+  assertEqual "" expected actual
+
+exampleLines :: [String]
+exampleLines = [ "# Generated by makepkg 4.2.1"
+               , "              # Tue Jun  9 20:30:57 UTC 2015"
+               , "pkgbase = brise-extra"
+               , "\tpkgdesc = Rime schema repository with extra methods installed (array30, scj6, stenotype, traditional wubi)"
+               , "\tpkgver = 0.35"
+               , "\tpkgrel = 2"
+               , "\turl = http://code.google.com/p/rimeime/"
+               , "\tarch = i686"
+               , "\tarch = x86_64"
+               , "\tlicense = GPL3"
+               , "\tmakedepends = cmake"
+               , "\tmakedepends = git"
+               , "\tmakedepends = librime>=1.2"
+               , "\tprovides = librime-data"
+               , "\tprovides = brise"
+               , "\tconflicts = librime<1.2"
+               , "\tconflicts = ibus-rime<1.2"
+               , "\tconflicts = brise"
+               , "\tsource = git+https://github.com/lotem/brise.git#tag=brise-0.35"
+               , "\tsource = Makefile.patch"
+               , "\tsha512sums = SKIP"
+               , "\tsha512sums = fb50ba9f6d5ea8aa81be8f1823040a175809e844e4426228188749ef178dec496aa44571cd5980845bc5392a1c1476871c676f32ba3ab917ddc1c01008ee6018"
+               , ""
+               , "pkgname = brise-extra"]
+
+fullExample :: String
+fullExample = Data.List.intercalate "\n" exampleLines
+
+fullExampleExpected :: SrcInfo
+fullExampleExpected = srcInfoData { name        = Just (pack "brise-extra")
+                                  , version     = Just (pack "0.35")
+                                  , release     = Just 2
+                                  , epoch       = Nothing
+                                  , arch        = Just [pack "i686", pack "x86_64"]
+                                  , licenses    = Just [pack "GPL3"]
+                                  , makeDepends = Just [pack "cmake", pack "git", pack "librime>=1.2"]
+                                  , provides    = Just [pack "librime-data", pack "brise"]
+                                  , conflicts   = Just [pack "librime<1.2", pack "ibus-rime<1.2", pack "brise"]
+                                  , sources     = Just [pack "git+https://github.com/lotem/brise.git#tag=brise-0.35", pack "Makefile.patch"]
+                                  , md5sums     = Nothing
+                                  , sha1sums    = Nothing
+                                  , sha224sums  = Nothing
+                                  , sha256sums  = Nothing
+                                  , sha384sums  = Nothing
+                                  , sha512sums  = Just [pack "SKIP", pack "fb50ba9f6d5ea8aa81be8f1823040a175809e844e4426228188749ef178dec496aa44571cd5980845bc5392a1c1476871c676f32ba3ab917ddc1c01008ee6018"]
+                                  }
+
+nominalExample :: Assertion
+nominalExample = do
+  let actual = parseConfig fullExample
+  -- print (Prelude.map parseSingleLine (Data.String.lines fullExample))
+  assertEqual "" fullExampleExpected actual

--- a/aura/tests/SrcInfoParserTest.hs
+++ b/aura/tests/SrcInfoParserTest.hs
@@ -1,3 +1,24 @@
+{-
+
+Copyright 2017 Jiehong Ma <email@majiehong.com>
+
+This file is part of Aura.
+
+Aura is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Aura is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Aura.  If not, see <http://www.gnu.org/licenses/>.
+
+-}
+
 module SrcInfoParserTest where
 
 import Test.Tasty
@@ -7,6 +28,7 @@ import Data.List
 import Data.Text
 import SrcInfoParser
 import Prelude
+import SrcInfoType
 
 tests :: TestTree
 tests = testGroup "Src Info Parser"


### PR DESCRIPTION
Hi Fosskers,

I created this pull request as I saw the plans for version 1.4 include a .SRCINFO parser in Haskell.

I took this as an opportunity to learn Haskell a bit, so thanks to this code I've officially written some Haskell, and learnt quite a lot in the process about MegaParsec, Tasty, Stack…

I'm sure this code may not look great, but I'm here to help and learn.

This parses a regular format of SRCINFO, but not the one where multiples values (like for arch) are given as a n-uplet.
I'm not sure how to continue on that direction as of yet, and I'd like some review on this code to try to steer it in the right direction.

Also, is there a close to sign/agree upon to give up intellectual property on this?
Do I need to copy a sub-set of the licence at the top of the files?