### PR TITLE
[WIP] Aura 2 - ALPM Bindings

### DIFF
--- a/alpm/Alpm.hs
+++ b/alpm/Alpm.hs
@@ -11,7 +11,7 @@ module Alpm
   -- | These are valid pure functions so long as the `Package` hasn't been freed.
   , name, version, description, url, filename, base, packager, md5sum, sha256sum, arch
   , buildDate, installDate, origin, size, installedSize, licenses, groups, signature
-  , provides
+  , depends, optdepends, conflicts, provides, deltas, replaces, database, validation
   -- ** Other
   , validmd5
   , required, optionals
@@ -29,6 +29,7 @@ module Alpm
   , alpmVersion
   ) where
 
+import           Alpm.Internal.Database
 import           Alpm.Internal.Error
 import           Alpm.Internal.Handle
 import           Alpm.Internal.Package
@@ -41,9 +42,6 @@ import           Foreign.C
 import           System.IO.Unsafe
 
 ---
-
--- | Wraps the type @alpm_db_t@.
-data Database
 
 -- | Wraps the type @alpm_trans_t@.
 data Transaction

--- a/alpm/Alpm.hs
+++ b/alpm/Alpm.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm where
+
+import           Alpm.List
+import qualified Data.Text as T
+import           Foreign
+import           Foreign.C
+import           System.IO.Unsafe
+
+---
+
+data Handle
+data Package
+data Database
+data Transaction
+
+data PkgGroup = PkgGroup { group_name :: CString
+                         , group_pkgs :: Ptr (List Package) }
+
+instance Storable PkgGroup where
+  sizeOf _ = 16
+  alignment _ = 8
+
+  peek ptr = do
+    name <- peekByteOff ptr 0
+    pkgs <- peekByteOff ptr 8
+    pure $ PkgGroup name pkgs
+
+  poke ptr (PkgGroup n ps) = do
+    pokeByteOff ptr 0 n
+    pokeByteOff ptr 8 ps
+
+data File = File { file_name :: CString
+                 , file_size :: CULong
+                 , file_mode :: CULong }
+
+instance Storable File where
+  sizeOf _ = 24
+  alignment _ = alignment (undefined :: CULong)
+
+  peek ptr = do
+    name <- peekByteOff ptr 0
+    size <- peekByteOff ptr 8
+    mode <- peekByteOff ptr 16
+    pure $ File name size mode
+
+  poke ptr (File n s m) = do
+    pokeByteOff ptr 0 n
+    pokeByteOff ptr 8 s
+    pokeByteOff ptr 16 m
+
+foreign import ccall unsafe "alpm.h alpm_version"
+  alpm_version :: CString
+
+alpmVersion :: T.Text
+alpmVersion = T.pack . unsafePerformIO $ peekCString alpm_version

--- a/alpm/Alpm.hs
+++ b/alpm/Alpm.hs
@@ -47,35 +47,28 @@ import           System.IO.Unsafe
 data Transaction
 
 -- | Wraps the type @alpm_group_t@.
-data PkgGroup = PkgGroup { group_name :: CString
-                         , group_pkgs :: Ptr (List Package) }
+data PkgGroup = PkgGroup { groupName :: CString
+                         , groupPkgs :: Ptr (List Package) }
 
 instance Storable PkgGroup where
   sizeOf _ = 16
   alignment _ = 8
 
-  peek ptr = do
-    name <- peekByteOff ptr 0
-    pkgs <- peekByteOff ptr 8
-    pure $ PkgGroup name pkgs
+  peek ptr = PkgGroup <$> peekByteOff ptr 0 <*> peekByteOff ptr 8
 
   poke ptr (PkgGroup n ps) = do
     pokeByteOff ptr 0 n
     pokeByteOff ptr 8 ps
 
-data File = File { file_name :: CString
-                 , file_size :: CULong
-                 , file_mode :: CULong }
+data File = File { fileName :: CString
+                 , fileSize :: CULong
+                 , fileMode :: CULong }
 
 instance Storable File where
   sizeOf _ = 24
   alignment _ = alignment (undefined :: CULong)
 
-  peek ptr = do
-    name <- peekByteOff ptr 0
-    size <- peekByteOff ptr 8
-    mode <- peekByteOff ptr 16
-    pure $ File name size mode
+  peek ptr = File <$> peekByteOff ptr 0 <*> peekByteOff ptr 8 <*> peekByteOff ptr 16
 
   poke ptr (File n s m) = do
     pokeByteOff ptr 0 n

--- a/alpm/Alpm.hs
+++ b/alpm/Alpm.hs
@@ -7,6 +7,12 @@ module Alpm
   , rootPath, dbPath, lockfile
   -- * Packages
   , Package
+  -- ** Fields
+  -- | These are valid pure functions so long as the `Package` hasn't been freed.
+  , name, version, description, url, filename, base, packager, md5sum, sha256sum, arch
+  , buildDate, installDate, origin, size, installedSize, licenses, groups, signature
+  , provides
+  -- ** Other
   , validmd5
   , required, optionals
   , shouldIgnore
@@ -20,14 +26,16 @@ module Alpm
   , currentError, errorMsg
   -- * Misc.
   , File(..)
-  , version
+  , alpmVersion
   ) where
 
 import           Alpm.Internal.Error
 import           Alpm.Internal.Handle
 import           Alpm.Internal.Package
 import           Alpm.List
+import           Data.Foldable (fold)
 import qualified Data.Text as T
+import qualified Data.Versions as V
 import           Foreign
 import           Foreign.C
 import           System.IO.Unsafe
@@ -93,8 +101,8 @@ foreign import ccall unsafe "alpm.h alpm_version"
   alpm_version :: CString
 
 -- | The current version of /alpm.h/ residing on your system.
-version :: T.Text
-version = T.pack . unsafePerformIO $ peekCString alpm_version
+alpmVersion :: V.SemVer
+alpmVersion = fold . V.semver . T.pack . unsafePerformIO $ peekCString alpm_version
 
 -- | A message corresponding to some error code.
 errorMsg :: Error -> T.Text

--- a/alpm/Alpm/Error.hsc
+++ b/alpm/Alpm/Error.hsc
@@ -1,0 +1,90 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Error where
+
+import Foreign
+import Foreign.C.String
+import Foreign.C.Types
+
+#include <alpm.h>
+
+-- | ALPM error codes, wrapping the enum type @alpm_errno_t@.
+newtype Error = Error { err :: CInt }
+
+instance Storable Error where
+  sizeOf _ = (#size alpm_errno_t)
+  alignment _ = alignment (undefined :: CInt)
+  peek ptr = Error <$> peekByteOff ptr 0
+  poke ptr (Error e) = pokeByteOff ptr 0 e
+
+-- | A message corresponding to some error code.
+foreign import ccall unsafe "alpm.h alpm_strerror"
+  alpm_strerror :: Error -> CString
+
+#{enum Error, Error,
+  err_memory = ALPM_ERR_MEMORY,
+  err_system = ALPM_ERR_SYSTEM,
+  err_badperms = ALPM_ERR_BADPERMS,
+  err_notAFile = ALPM_ERR_NOT_A_FILE,
+  err_notADir = ALPM_ERR_NOT_A_DIR,
+  err_wrongArgs = ALPM_ERR_WRONG_ARGS,
+  err_diskSpace = ALPM_ERR_DISK_SPACE,
+
+  err_handleNull = ALPM_ERR_HANDLE_NULL,
+  err_handleNotNull = ALPM_ERR_HANDLE_NOT_NULL,
+  err_handleLock = ALPM_ERR_HANDLE_LOCK,
+
+  err_dbOpen = ALPM_ERR_DB_OPEN,
+  err_dbCreate = ALPM_ERR_DB_CREATE,
+  err_dbNull = ALPM_ERR_DB_NULL,
+  err_dbNotNull = ALPM_ERR_DB_NOT_NULL,
+  err_dbNotFound = ALPM_ERR_DB_NOT_FOUND,
+  err_dbInvalid = ALPM_ERR_DB_INVALID,
+  err_dbInvalidSig = ALPM_ERR_DB_INVALID_SIG,
+  err_dbVersion = ALPM_ERR_DB_VERSION,
+  err_dbWrite = ALPM_ERR_DB_WRITE,
+  err_dbRemove = ALPM_ERR_DB_REMOVE,
+
+  err_serverBadUrl = ALPM_ERR_SERVER_BAD_URL,
+  err_serverNone = ALPM_ERR_SERVER_NONE,
+
+  err_transNotNull = ALPM_ERR_TRANS_NOT_NULL,
+  err_transNull = ALPM_ERR_TRANS_NULL,
+  err_transDupTarget = ALPM_ERR_TRANS_DUP_TARGET,
+  err_transNotInit = ALPM_ERR_TRANS_NOT_INITIALIZED,
+  err_transNotPrep = ALPM_ERR_TRANS_NOT_PREPARED,
+  err_transAbort = ALPM_ERR_TRANS_ABORT,
+  err_transType = ALPM_ERR_TRANS_TYPE,
+  err_transNotLocked = ALPM_ERR_TRANS_NOT_LOCKED,
+  err_transHookFailed = ALPM_ERR_TRANS_HOOK_FAILED,
+
+  err_pkgNotFound = ALPM_ERR_PKG_NOT_FOUND,
+  err_pkgIgnored = ALPM_ERR_PKG_IGNORED,
+  err_pkgInvalid = ALPM_ERR_PKG_INVALID,
+  err_pkgChecksum = ALPM_ERR_PKG_INVALID_CHECKSUM,
+  err_pkgSig = ALPM_ERR_PKG_INVALID_SIG,
+  err_pkgMissingSig = ALPM_ERR_PKG_MISSING_SIG,
+  err_pkgOpen = ALPM_ERR_PKG_OPEN,
+  err_pkgCantRemove = ALPM_ERR_PKG_CANT_REMOVE,
+  err_pkgName = ALPM_ERR_PKG_INVALID_NAME,
+  err_pkgArch = ALPM_ERR_PKG_INVALID_ARCH,
+  err_pkgRepoNotFound = ALPM_ERR_PKG_REPO_NOT_FOUND,
+
+  err_sigMissing = ALPM_ERR_SIG_MISSING,
+  err_sigInvalid = ALPM_ERR_SIG_INVALID,
+
+  err_deltaInvalid = ALPM_ERR_DLT_INVALID,
+  err_deltaPatchFailed = ALPM_ERR_DLT_PATCHFAILED,
+
+  err_depsUnsatisfied = ALPM_ERR_UNSATISFIED_DEPS,
+  err_depsConflicting = ALPM_ERR_CONFLICTING_DEPS,
+  err_depsFileConflict = ALPM_ERR_FILE_CONFLICTS,
+
+  err_retrieve = ALPM_ERR_RETRIEVE,
+  err_invalidRegex = ALPM_ERR_INVALID_REGEX,
+
+  err_libarchive = ALPM_ERR_LIBARCHIVE,
+  err_libcurl = ALPM_ERR_LIBCURL,
+  err_download = ALPM_ERR_EXTERNAL_DOWNLOAD,
+  err_gpgme = ALPM_ERR_GPGME
+}

--- a/alpm/Alpm/Internal/Database.hs
+++ b/alpm/Alpm/Internal/Database.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
-
 module Alpm.Internal.Database where
 
 import Foreign

--- a/alpm/Alpm/Internal/Database.hs
+++ b/alpm/Alpm/Internal/Database.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Internal.Database where
+
+import Foreign
+
+---
+
+type Database = Ptr RawDatabase
+
+-- | Wraps the type @alpm_db_t@.
+data RawDatabase

--- a/alpm/Alpm/Internal/Dependency.hsc
+++ b/alpm/Alpm/Internal/Dependency.hsc
@@ -1,0 +1,37 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Internal.Dependency where
+
+import Alpm.Internal.Enums
+import Foreign
+import Foreign.C.String
+import Foreign.C.Types
+
+#include <alpm.h>
+
+---
+
+-- | Wraps the type @alpm_depend_t@.
+data Dependency = Dependency { name :: CString
+                             , version :: CString
+                             , desc :: CString
+                             , hash :: CULong
+                             , mode :: ComparisonMode }
+
+instance Storable Dependency where
+  sizeOf _ = (#size alpm_depend_t)
+  alignment _ = alignment (undefined :: CULong)
+
+  peek ptr = Dependency
+    <$> (#peek alpm_depend_t, name) ptr
+    <*> (#peek alpm_depend_t, version) ptr
+    <*> (#peek alpm_depend_t, desc) ptr
+    <*> (#peek alpm_depend_t, name_hash) ptr
+    <*> (#peek alpm_depend_t, mod) ptr
+
+  poke ptr (Dependency n v d h m) = do
+    (#poke alpm_depend_t, name) ptr n
+    (#poke alpm_depend_t, version) ptr v
+    (#poke alpm_depend_t, desc) ptr d
+    (#poke alpm_depend_t, name_hash) ptr h
+    (#poke alpm_depend_t, mod) ptr m

--- a/alpm/Alpm/Internal/Enums.hsc
+++ b/alpm/Alpm/Internal/Enums.hsc
@@ -1,0 +1,25 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Internal.Enums where
+
+import Foreign.C.Types
+
+#include <alpm.h>
+
+---
+
+-- | Where did a `Package` come from?
+newtype PkgOrigin = PkgOrigin CInt deriving (Eq)
+
+#{enum PkgOrigin, PkgOrigin,
+   po_file = ALPM_PKG_FROM_FILE,
+   po_localdb = ALPM_PKG_FROM_LOCALDB,
+   po_syncdb = ALPM_PKG_FROM_SYNCDB
+ }
+
+newtype InstalledAs = InstalledAs CInt deriving (Eq)
+
+#{enum InstalledAs, InstalledAs,
+  ia_explicit = ALPM_PKG_REASON_EXPLICIT,
+  ia_dependency = ALPM_PKG_REASON_DEPEND
+ }

--- a/alpm/Alpm/Internal/Enums.hsc
+++ b/alpm/Alpm/Internal/Enums.hsc
@@ -9,6 +9,7 @@ module Alpm.Internal.Enums
   , ComparisonMode(..)
   , cm_any, cm_eq, cm_ge, cm_le, cm_gt, cm_lt
   , SigLevel(..)
+  , siglevels
   , sl_package, sl_pkg_optional, sl_pkg_marginal, sl_pkg_unknown, sl_database, sl_db_optional
   , sl_db_marginal, sl_db_unknown, sl_default
   , Validation(..)
@@ -39,15 +40,19 @@ instance Storable ComparisonMode where
   poke ptr (ComparisonMode e) = pokeByteOff ptr 0 e
 
 -- | Wraps the enum @alpm_siglevel_t@.
-newtype SigLevel = SigLevel CInt deriving (Eq)
+newtype SigLevel = SigLevel CInt deriving (Eq, Show)
 
 instance Monoid SigLevel where
   mempty = SigLevel 0
 
   SigLevel a `mappend` SigLevel b = SigLevel $ a .|. b
 
--- siglevels :: SigLevel -> [SigLevel]
--- siglevels =
+-- | Potentially splits up a `SigLevel` value that might have been bitwise
+-- composed by ALPM to represent multiple signature verification options.
+siglevels :: SigLevel -> [SigLevel]
+siglevels (SigLevel s) = foldr f [] [0,1,2,3,10,11,12,13,30]
+  where f n acc | testBit s n = SigLevel (2 ^ n) : acc
+                | otherwise = acc
 
 -- | The method used to validate a package. These values can be bitwise
 -- composed within ALPM to represent the desire for multiple validation

--- a/alpm/Alpm/Internal/Enums.hsc
+++ b/alpm/Alpm/Internal/Enums.hsc
@@ -2,6 +2,7 @@
 
 module Alpm.Internal.Enums where
 
+import Foreign
 import Foreign.C.Types
 
 #include <alpm.h>
@@ -22,4 +23,22 @@ newtype InstalledAs = InstalledAs CInt deriving (Eq)
 #{enum InstalledAs, InstalledAs,
   ia_explicit = ALPM_PKG_REASON_EXPLICIT,
   ia_dependency = ALPM_PKG_REASON_DEPEND
+ }
+
+-- | Wraps the enum @alpm_depmod_t@.
+newtype ComparisonMode = ComparisonMode CInt deriving (Eq)
+
+instance Storable ComparisonMode where
+  sizeOf _ = (#size alpm_depmod_t)
+  alignment _ = alignment (undefined :: CInt)
+  peek ptr = ComparisonMode <$> peekByteOff ptr 0
+  poke ptr (ComparisonMode e) = pokeByteOff ptr 0 e
+
+#{enum ComparisonMode, ComparisonMode,
+   cm_any = ALPM_DEP_MOD_ANY,
+   cm_eq = ALPM_DEP_MOD_EQ,
+   cm_ge = ALPM_DEP_MOD_GE,
+   cm_le = ALPM_DEP_MOD_LE,
+   cm_gt = ALPM_DEP_MOD_GT,
+   cm_lt = ALPM_DEP_MOD_LT
  }

--- a/alpm/Alpm/Internal/Enums.hsc
+++ b/alpm/Alpm/Internal/Enums.hsc
@@ -1,6 +1,20 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Alpm.Internal.Enums where
+module Alpm.Internal.Enums
+  (
+    PkgOrigin(..)
+  , po_file, po_localdb, po_syncdb
+  , InstalledAs(..)
+  , ia_explicit, ia_dependency
+  , ComparisonMode(..)
+  , cm_any, cm_eq, cm_ge, cm_le, cm_gt, cm_lt
+  , SigLevel(..)
+  , sl_package, sl_pkg_optional, sl_pkg_marginal, sl_pkg_unknown, sl_database, sl_db_optional
+  , sl_db_marginal, sl_db_unknown, sl_default
+  , Validation(..)
+  , validations
+  , vm_unknown, vm_none, vm_md5, vm_sha256, vm_sig
+  ) where
 
 import Data.Bits
 import Foreign
@@ -13,18 +27,7 @@ import Foreign.C.Types
 -- | Where did a `Package` come from?
 newtype PkgOrigin = PkgOrigin CInt deriving (Eq)
 
-#{enum PkgOrigin, PkgOrigin,
-   po_file = ALPM_PKG_FROM_FILE,
-   po_localdb = ALPM_PKG_FROM_LOCALDB,
-   po_syncdb = ALPM_PKG_FROM_SYNCDB
- }
-
 newtype InstalledAs = InstalledAs CInt deriving (Eq)
-
-#{enum InstalledAs, InstalledAs,
-  ia_explicit = ALPM_PKG_REASON_EXPLICIT,
-  ia_dependency = ALPM_PKG_REASON_DEPEND
- }
 
 -- | Wraps the enum @alpm_depmod_t@.
 newtype ComparisonMode = ComparisonMode CInt deriving (Eq)
@@ -35,6 +38,48 @@ instance Storable ComparisonMode where
   peek ptr = ComparisonMode <$> peekByteOff ptr 0
   poke ptr (ComparisonMode e) = pokeByteOff ptr 0 e
 
+-- | Wraps the enum @alpm_siglevel_t@.
+newtype SigLevel = SigLevel CInt deriving (Eq)
+
+instance Monoid SigLevel where
+  mempty = SigLevel 0
+
+  SigLevel a `mappend` SigLevel b = SigLevel $ a .|. b
+
+-- siglevels :: SigLevel -> [SigLevel]
+-- siglevels =
+
+-- | The method used to validate a package. These values can be bitwise
+-- composed within ALPM to represent the desire for multiple validation
+-- methods. Use `validations` to split these back up.
+newtype Validation = Validation CInt deriving (Eq, Show)
+
+instance Monoid Validation where
+  mempty = Validation 0
+
+  Validation a `mappend` Validation b = Validation $ a .|. b
+
+-- | Potentially splits up a `Validation` value that might have been bitwise
+-- composed by ALPM to represent multiple validation methods in a single value.
+validations :: Validation -> [Validation]
+validations v@(Validation 0) = [v]  -- UNKNOWN
+validations (Validation v) = foldr f [] [0..3]
+  where f n acc | testBit v n = Validation (2 ^ n) : acc
+                | otherwise = acc
+
+---
+
+#{enum PkgOrigin, PkgOrigin,
+   po_file = ALPM_PKG_FROM_FILE,
+   po_localdb = ALPM_PKG_FROM_LOCALDB,
+   po_syncdb = ALPM_PKG_FROM_SYNCDB
+ }
+
+#{enum InstalledAs, InstalledAs,
+  ia_explicit = ALPM_PKG_REASON_EXPLICIT,
+  ia_dependency = ALPM_PKG_REASON_DEPEND
+ }
+
 #{enum ComparisonMode, ComparisonMode,
    cm_any = ALPM_DEP_MOD_ANY,
    cm_eq = ALPM_DEP_MOD_EQ,
@@ -44,23 +89,22 @@ instance Storable ComparisonMode where
    cm_lt = ALPM_DEP_MOD_LT
  }
 
--- | The method used to validate a package. These values can be bitwise
--- composed within ALPM to represent the desire for multiple validation
--- methods. Use `validations` to split these back up.
-newtype Validation = Validation CInt deriving (Eq)
+#{enum SigLevel, SigLevel,
+   sl_package      = ALPM_SIG_PACKAGE,
+   sl_pkg_optional = ALPM_SIG_PACKAGE_OPTIONAL,
+   sl_pkg_marginal = ALPM_SIG_PACKAGE_MARGINAL_OK,
+   sl_pkg_unknown  = ALPM_SIG_PACKAGE_UNKNOWN_OK,
+   sl_database     = ALPM_SIG_DATABASE,
+   sl_db_optional  = ALPM_SIG_DATABASE_OPTIONAL,
+   sl_db_marginal  = ALPM_SIG_DATABASE_MARGINAL_OK,
+   sl_db_unknown   = ALPM_SIG_DATABASE_UNKNOWN_OK,
+   sl_default      = ALPM_SIG_USE_DEFAULT
+ }
 
 #{enum Validation, Validation,
   vm_unknown = ALPM_PKG_VALIDATION_UNKNOWN,
-  vm_none = ALPM_PKG_VALIDATION_NONE,
-  vm_md5 = ALPM_PKG_VALIDATION_MD5SUM,
-  vm_sha256 = ALPM_PKG_VALIDATION_SHA256SUM,
-  vm_sig = ALPM_PKG_VALIDATION_SIGNATURE
+  vm_none    = ALPM_PKG_VALIDATION_NONE,
+  vm_md5     = ALPM_PKG_VALIDATION_MD5SUM,
+  vm_sha256  = ALPM_PKG_VALIDATION_SHA256SUM,
+  vm_sig     = ALPM_PKG_VALIDATION_SIGNATURE
  }
-
--- | Potentially splits up a `Validation` value that might have been bitwise
--- composed by ALPM to represent multiple validation methods in a single value.
-validations :: Validation -> [Validation]
-validations v@(Validation 0) = [v]  -- UNKNOWN
-validations (Validation v) = foldr f [] [0..3]
-  where f n acc | testBit v n = Validation (2 ^ n) : acc
-                | otherwise = acc

--- a/alpm/Alpm/Internal/Error.hsc
+++ b/alpm/Alpm/Internal/Error.hsc
@@ -1,6 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Alpm.Error where
+module Alpm.Internal.Error where
 
 import Foreign
 import Foreign.C.String

--- a/alpm/Alpm/Internal/Handle.hs
+++ b/alpm/Alpm/Internal/Handle.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Internal.Handle where
+
+import           Alpm.Internal.Error
+import qualified Data.Text as T
+import           Foreign
+import           Foreign.C
+import           System.IO.Unsafe
+
+---
+
+-- | A connection to underlying ALPM machinery. Must be constructed via
+-- `initialize` and released via `close` when finished.
+type Handle = Ptr RawHandle
+
+-- | Wraps the type @alpm_handle_t@.
+data RawHandle
+
+-- TODO: Is this thread-safe? Can multiple test suites call this at the same time?
+-- Or maybe we just open one Handle at the beginning, and go willy-nilly.
+-- | Most other functions can't be used until this is called.
+foreign import ccall unsafe "alpm.h alpm_initialize"
+  alpm_init :: CString -> CString -> Ptr Error -> IO (Ptr RawHandle)
+
+-- | Releases internal ALPM memory, disconnects from the database, and
+-- removes the lock file (if present). The library (mostly) can't be used after
+-- this is called. Returns @0@ if successful.
+foreign import ccall unsafe "alpm.h alpm_release"
+  close :: Handle -> IO CInt
+
+foreign import ccall unsafe "alpm.h alpm_option_get_root"
+  alpm_option_get_root :: Handle -> CString
+
+-- | The root of the OS, set by `initialize`.
+rootPath :: Handle -> T.Text
+rootPath = T.pack . unsafePerformIO . peekCString . alpm_option_get_root
+
+foreign import ccall unsafe "alpm.h alpm_option_get_dbpath"
+  alpm_option_get_dbpath :: Handle -> CString
+
+-- | The path to the database directory, set by `initialize`.
+dbPath :: Handle -> T.Text
+dbPath = T.pack . unsafePerformIO . peekCString . alpm_option_get_dbpath
+
+foreign import ccall unsafe "alpm.h alpm_option_get_lockfile"
+  alpm_option_get_lockfile :: Handle -> CString
+
+-- | The location of the database lockfile.
+lockfile :: Handle -> T.Text
+lockfile = T.pack . unsafePerformIO . peekCString . alpm_option_get_lockfile

--- a/alpm/Alpm/Internal/Package.hs
+++ b/alpm/Alpm/Internal/Package.hs
@@ -25,13 +25,17 @@ data RawPackage
 foreign import ccall unsafe "alpm.h alpm_pkg_load"
   alpm_pkg_load :: Handle -> CString -> CInt -> CInt -> IO (Ptr (Ptr RawPackage))
 
+-- TODO: Necessary?
 -- | Find a `Package` in a `List` by name.
 foreign import ccall unsafe "alpm.h alpm_pkg_find"
-  alpm_pkg_find :: Ptr (List RawPackage) -> CString -> Package
+  find :: Ptr (List RawPackage) -> CString -> Package
 
 -- | Free a `Package`'s memory. Returns @0@ on success, @-1@ on error.
 foreign import ccall unsafe "alpm.h alpm_pkg_free"
   alpm_pkg_free :: Package -> IO CInt
+
+foreign import ccall unsafe "alpm.h alpm_pkg_vercmp"
+  alpm_pkg_vercmp :: CString -> CString -> CInt
 
 -- | Check a `Package`'s validity. @0@ when valid, @-1@ otherwise.
 foreign import ccall unsafe "alpm.h alpm_pkg_checkmd5sum"

--- a/alpm/Alpm/Internal/Package.hs
+++ b/alpm/Alpm/Internal/Package.hs
@@ -3,8 +3,10 @@
 module Alpm.Internal.Package where
 
 import           Alpm.Internal.Handle
+import           Alpm.Internal.Enums
 import           Alpm.List
 import qualified Data.Text as T
+import           Data.Versions
 import           Foreign
 import           Foreign.C.String
 import           Foreign.C.Types
@@ -46,7 +48,7 @@ foreign import ccall unsafe "alpm.h alpm_pkg_compute_requiredby"
 required :: Package -> IO [T.Text]
 required p = do
   ptr <- alpm_pkg_requiredby p
-  items <- sequence . map peekCString $ toList ptr
+  items <- mapM peekCString $ toList ptr
   alpm_list_free ptr
   pure $ map T.pack items
 
@@ -59,7 +61,7 @@ foreign import ccall unsafe "alpm.h alpm_pkg_compute_optionalfor"
 optionals :: Package -> IO [T.Text]
 optionals p = do
   ptr <- alpm_pkg_optionals p
-  items <- sequence . map peekCString $ toList ptr
+  items <- mapM peekCString $ toList ptr
   alpm_list_free ptr
   pure $ map T.pack items
 
@@ -77,3 +79,121 @@ foreign import ccall unsafe "alpm.h alpm_pkg_get_filename"
 
 filename :: Package -> T.Text
 filename = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_filename
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_base"
+  alpm_pkg_get_base :: Package -> CString
+
+base :: Package -> T.Text
+base = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_base
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_name"
+  alpm_pkg_get_name :: Package -> CString
+
+name :: Package -> T.Text
+name = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_name
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_version"
+  alpm_pkg_get_version :: Package -> CString
+
+version :: Package -> Either ParsingError Versioning
+version = parseV . T.pack . unsafePerformIO . peekCString . alpm_pkg_get_version
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_desc"
+  alpm_pkg_get_desc :: Package -> CString
+
+description :: Package -> T.Text
+description = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_desc
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_url"
+  alpm_pkg_get_url :: Package -> CString
+
+url :: Package -> T.Text
+url = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_url
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_packager"
+  alpm_pkg_get_packager :: Package -> CString
+
+packager :: Package -> T.Text
+packager = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_packager
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_md5sum"
+  alpm_pkg_get_md5sum :: Package -> CString
+
+md5sum :: Package -> T.Text
+md5sum = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_md5sum
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_sha256sum"
+  alpm_pkg_get_sha256sum :: Package -> CString
+
+sha256sum :: Package -> T.Text
+sha256sum = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_sha256sum
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_arch"
+  alpm_pkg_get_arch :: Package -> CString
+
+arch :: Package -> T.Text
+arch = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_arch
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_builddate"
+  alpm_pkg_get_builddate :: Package -> CLong
+
+-- TODO: Convert this to an actual time type!
+-- | The timestamp of when the `Package` was built.
+buildDate :: Package -> Int64
+buildDate = fromIntegral . alpm_pkg_get_builddate
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_installdate"
+  alpm_pkg_get_installdate :: Package -> CLong
+
+-- TODO: Convert this to an actual time type!
+-- | The timestamp of when the `Package` was installed.
+installDate :: Package -> Int64
+installDate = fromIntegral . alpm_pkg_get_installdate
+
+-- | Where did this `Package` come from?
+foreign import ccall unsafe "alpm.h alpm_pkg_get_origin"
+  origin :: Package -> PkgOrigin
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_size"
+  alpm_pkg_get_size :: Package -> CLong
+
+-- | The size of this `Package` in bytes. Only available for packages from a
+-- sync database or package file.
+size :: Package -> Maybe Int64
+size p | origin p == po_localdb = Nothing
+       | otherwise = Just . fromIntegral $ alpm_pkg_get_size p
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_isize"
+  alpm_pkg_get_isize :: Package -> CLong
+
+installedSize :: Package -> Int64
+installedSize = fromIntegral . alpm_pkg_get_isize
+
+-- | Was a `Package` installed explicitely, or as a dependency for another?
+foreign import ccall unsafe "alpm.h alpm_pkg_get_reason"
+  installedAs :: Package -> InstalledAs
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_licenses"
+  alpm_pkg_get_licenses :: Package -> Ptr (List CString)
+
+licenses :: Package -> [T.Text]
+licenses = map T.pack . unsafePerformIO . mapM peekCString . toList . alpm_pkg_get_licenses
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_groups"
+  alpm_pkg_get_groups :: Package -> Ptr (List CString)
+
+groups :: Package -> [T.Text]
+groups = map T.pack . unsafePerformIO . mapM peekCString . toList . alpm_pkg_get_groups
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_provides"
+  alpm_pkg_get_provides :: Package -> Ptr (List CString)
+
+provides :: Package -> [T.Text]
+provides = map T.pack . unsafePerformIO . mapM peekCString . toList . alpm_pkg_get_provides
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_base64_sig"
+  alpm_pkg_get_base64_sig :: Package -> CString
+
+-- | The base 64 encoded package signature.
+signature :: Package -> T.Text
+signature = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_base64_sig

--- a/alpm/Alpm/Internal/Package.hs
+++ b/alpm/Alpm/Internal/Package.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.Internal.Package where
+
+import           Alpm.Internal.Handle
+import           Alpm.List
+import qualified Data.Text as T
+import           Foreign
+import           Foreign.C.String
+import           Foreign.C.Types
+import           System.IO.Unsafe
+
+---
+
+-- | An ALPM package.
+type Package = Ptr RawPackage
+
+-- | Wraps the type @alpm_pkg_t@.
+data RawPackage
+
+foreign import ccall unsafe "alpm.h alpm_pkg_load"
+  alpm_pkg_load :: Handle -> CString -> CInt -> CInt -> IO (Ptr (Ptr RawPackage))
+
+-- | Find a `Package` in a `List` by name.
+foreign import ccall unsafe "alpm.h alpm_pkg_find"
+  alpm_pkg_find :: Ptr (List RawPackage) -> CString -> Package
+
+-- | Free a `Package`'s memory. Returns @0@ on success, @-1@ on error.
+foreign import ccall unsafe "alpm.h alpm_pkg_free"
+  alpm_pkg_free :: Package -> IO CInt
+
+-- | Check a `Package`'s validity. @0@ when valid, @-1@ otherwise.
+foreign import ccall unsafe "alpm.h alpm_pkg_checkmd5sum"
+  alpm_pkg_checkmd5 :: Package -> IO CInt
+
+-- | Does a `Package` have a valid MD5 checksum?
+validmd5 :: Package -> Bool
+validmd5 p = 0 == unsafePerformIO (alpm_pkg_checkmd5 p)
+
+-- | A list of packages who require the given `Package`. The `List` is newly
+-- allocated and must be freed by us when we're done with it.
+foreign import ccall unsafe "alpm.h alpm_pkg_compute_requiredby"
+  alpm_pkg_requiredby :: Package -> IO (Ptr (List CString))
+
+-- | A list of packages that require the given package as a dependency.
+required :: Package -> IO [T.Text]
+required p = do
+  ptr <- alpm_pkg_requiredby p
+  items <- sequence . map peekCString $ toList ptr
+  alpm_list_free ptr
+  pure $ map T.pack items
+
+-- | A list of packages which optionally require the given `Package`. The
+-- `List` is newly allocated and must be freed by us when we're done with it.
+foreign import ccall unsafe "alpm.h alpm_pkg_compute_optionalfor"
+  alpm_pkg_optionals :: Package -> IO (Ptr (List CString))
+
+-- | A list of packages which have the given package as an optional dependency.
+optionals :: Package -> IO [T.Text]
+optionals p = do
+  ptr <- alpm_pkg_optionals p
+  items <- sequence . map peekCString $ toList ptr
+  alpm_list_free ptr
+  pure $ map T.pack items
+
+-- | Should a given `Package` be ignored? @1@ if the package is present in
+-- @IgnorePkg@ or is part of an ignored group, @0@ otherwise.
+foreign import ccall unsafe "alpm.h alpm_pkg_should_ignore"
+  alpm_pkg_should_ignore :: Handle -> Package -> CInt
+
+-- | Should a given `Package` be ignored?
+shouldIgnore :: Handle -> Package -> Bool
+shouldIgnore h p = alpm_pkg_should_ignore h p == 1
+
+foreign import ccall unsafe "alpm.h alpm_pkg_get_filename"
+  alpm_pkg_get_filename :: Package -> CString
+
+filename :: Package -> T.Text
+filename = T.pack . unsafePerformIO . peekCString . alpm_pkg_get_filename

--- a/alpm/Alpm/Internal/Package.hs
+++ b/alpm/Alpm/Internal/Package.hs
@@ -22,8 +22,8 @@ type Package = Ptr RawPackage
 -- | Wraps the type @alpm_pkg_t@.
 data RawPackage
 
-foreign import ccall unsafe "alpm.h alpm_pkg_load"
-  alpm_pkg_load :: Handle -> CString -> CInt -> CInt -> IO (Ptr (Ptr RawPackage))
+--foreign import ccall unsafe "alpm.h alpm_pkg_load"
+--  alpm_pkg_load :: Handle -> CString -> CInt -> CInt -> IO (Ptr (Ptr RawPackage))
 
 -- TODO: Necessary?
 -- | Find a `Package` in a `List` by name.

--- a/alpm/Alpm/List.hs
+++ b/alpm/Alpm/List.hs
@@ -13,8 +13,34 @@ import System.IO.Unsafe
 
 ---
 
+{-
+
+typedef struct __alpm_list_t {
+    void * data;
+    struct __alpm_list_t * prev;
+    struct __alpm_list_t * next;
+} alpm_list_t;
+
+-}
+
 -- | The ALPM-specific list type, used heavily by the main ALPM library.
 data List a = List (Ptr ()) (Ptr (List a)) (Ptr (List a))
+
+instance Storable (List a) where
+  sizeOf _ = 24
+  alignment _ = 8
+
+  peek p = do
+    v0 <- peekByteOff p 0
+    v1 <- peekByteOff p 8
+    v2 <- peekByteOff p 16
+    return $ List v0 v1 v2
+
+  poke p (List v0 v1 v2) = do
+    pokeByteOff p 0 v0
+    pokeByteOff p 8 v1
+    pokeByteOff p 16 v2
+    return ()
 
 foreign import ccall unsafe "alpm_list.h alpm_list_free"
   alpm_list_free :: Ptr (List a) -> IO ()
@@ -25,9 +51,11 @@ foreign import ccall unsafe "alpm_list.h alpm_list_next"
 -- | Fetch the head of the list.
 item :: Storable a => Ptr (List a) -> IO a
 item p = do
-  voidPtr <- peek $ plusPtr p 0
+  List voidPtr _ _ <- peek p
   peek $ castPtr voidPtr
 
+-- TODO: Should this be in `IO`? Otherwise it might not return the correct
+-- list if the underlying data changes.
 -- | /O(n)/. Convert an ALPM list into a Haskell list. Assumption: if (at any
 -- recursive level) the list `Ptr` is non-null, then its data `Ptr` will also
 -- point to valid, non-null data.

--- a/alpm/Alpm/List.hs
+++ b/alpm/Alpm/List.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Alpm.List
+  ( List
+  , toList
+  , item
+  -- * Low-level functions
+  , alpm_list_free
+  ) where
+
+import Foreign
+import System.IO.Unsafe
+
+---
+
+-- | The ALPM-specific list type, used heavily by the main ALPM library.
+data List a = List (Ptr ()) (Ptr (List a)) (Ptr (List a))
+
+foreign import ccall unsafe "alpm_list.h alpm_list_free"
+  alpm_list_free :: Ptr (List a) -> IO ()
+
+foreign import ccall unsafe "alpm_list.h alpm_list_next"
+  alpm_list_next :: Ptr (List a) -> IO (Ptr (List a))
+
+-- | Fetch the head of the list.
+item :: Storable a => Ptr (List a) -> IO a
+item p = do
+  voidPtr <- peek $ plusPtr p 0
+  peek $ castPtr voidPtr
+
+-- | /O(n)/. Convert an ALPM list into a Haskell list. Assumption: if (at any
+-- recursive level) the list `Ptr` is non-null, then its data `Ptr` will also
+-- point to valid, non-null data.
+toList :: Storable a => Ptr (List a) -> [a]
+toList ptr = unsafePerformIO $ work ptr
+  where work p | p == nullPtr = pure []
+               | otherwise = do
+                   curr <- item p
+                   next <- alpm_list_next p
+                   (curr :) <$> work next

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -20,7 +20,7 @@ library
       base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
-    , versions >= 3.0.2.1 && < 3.1
+    , versions >= 3.1.0.1 && < 3.2
   exposed-modules:
       Alpm
       Alpm.Internal.Database
@@ -42,7 +42,7 @@ test-suite alpm-test
       base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
-    , versions >= 3.0.2.1 && < 3.1
+    , versions >= 3.1.0.1 && < 3.2
     , alpm
     , tasty >=0.11 && <0.12
     , tasty-hunit >=0.9 && <0.10

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -24,7 +24,6 @@ library
       Alpm
       Alpm.Error
       Alpm.List
-      List
   default-language: Haskell2010
 
 test-suite alpm-test

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -18,6 +18,25 @@ library
       alpm
   build-depends:
       base >=4.9 && <4.10
+    , bindings-DSL >= 1.0 && < 1.1
+    , text
   exposed-modules:
+      Alpm
       Alpm.List
+      List
+  default-language: Haskell2010
+
+test-suite alpm-test
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  hs-source-dirs:
+      test
+  ghc-options: -fwarn-unused-imports -fwarn-unused-binds -threaded
+  build-depends:
+      base >=4.9 && <4.10
+    , bindings-DSL >= 1.0 && < 1.1
+    , text
+    , alpm
+    , tasty >=0.11 && <0.12
+    , tasty-hunit >=0.9 && <0.10
   default-language: Haskell2010

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -22,6 +22,7 @@ library
     , text
   exposed-modules:
       Alpm
+      Alpm.Error
       Alpm.List
       List
   default-language: Haskell2010

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -23,6 +23,7 @@ library
     , versions >= 3.0.1.1 && < 3.1
   exposed-modules:
       Alpm
+      Alpm.Internal.Database
       Alpm.Internal.Dependency
       Alpm.Internal.Enums
       Alpm.Internal.Error

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -23,6 +23,7 @@ library
     , versions >= 3.0.1.1 && < 3.1
   exposed-modules:
       Alpm
+      Alpm.Internal.Dependency
       Alpm.Internal.Enums
       Alpm.Internal.Error
       Alpm.Internal.Handle

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -1,0 +1,23 @@
+-- This file has been generated from package.yaml by hpack version 0.17.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           alpm
+version:        0.1.0.0
+author:         Colin Woodbury
+maintainer:     colingw@gmail.com
+license:        BSD3
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+  hs-source-dirs:
+      ./.
+  ghc-options: -fwarn-unused-imports -fwarn-unused-binds
+  extra-libraries:
+      alpm
+  build-depends:
+      base >=4.9 && <4.10
+  exposed-modules:
+      Alpm.List
+  default-language: Haskell2010

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -13,14 +13,14 @@ cabal-version:  >= 1.10
 library
   hs-source-dirs:
       ./.
-  ghc-options: -fwarn-unused-imports -fwarn-unused-binds
+  ghc-options: -fwarn-unused-imports -fwarn-unused-binds -fwarn-name-shadowing -fwarn-unused-matches
   extra-libraries:
       alpm
   build-depends:
       base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
-    , versions >= 3.0.1.1 && < 3.1
+    , versions >= 3.0.2.1 && < 3.1
   exposed-modules:
       Alpm
       Alpm.Internal.Database
@@ -37,12 +37,12 @@ test-suite alpm-test
   main-is: Test.hs
   hs-source-dirs:
       test
-  ghc-options: -fwarn-unused-imports -fwarn-unused-binds -threaded
+  ghc-options: -fwarn-unused-imports -fwarn-unused-binds -fwarn-name-shadowing -fwarn-unused-matches -threaded
   build-depends:
       base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
-    , versions >= 3.0.1.1 && < 3.1
+    , versions >= 3.0.2.1 && < 3.1
     , alpm
     , tasty >=0.11 && <0.12
     , tasty-hunit >=0.9 && <0.10

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -22,7 +22,9 @@ library
     , text
   exposed-modules:
       Alpm
-      Alpm.Error
+      Alpm.Internal.Error
+      Alpm.Internal.Handle
+      Alpm.Internal.Package
       Alpm.List
   default-language: Haskell2010
 

--- a/alpm/alpm.cabal
+++ b/alpm/alpm.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           alpm
-version:        0.1.0.0
+version:        1.0.0
 author:         Colin Woodbury
 maintainer:     colingw@gmail.com
 license:        BSD3
@@ -17,11 +17,13 @@ library
   extra-libraries:
       alpm
   build-depends:
-      base >=4.9 && <4.10
+      base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
+    , versions >= 3.0.1.1 && < 3.1
   exposed-modules:
       Alpm
+      Alpm.Internal.Enums
       Alpm.Internal.Error
       Alpm.Internal.Handle
       Alpm.Internal.Package
@@ -35,9 +37,10 @@ test-suite alpm-test
       test
   ghc-options: -fwarn-unused-imports -fwarn-unused-binds -threaded
   build-depends:
-      base >=4.9 && <4.10
+      base >= 4.8 && < 4.10
     , bindings-DSL >= 1.0 && < 1.1
     , text
+    , versions >= 3.0.1.1 && < 3.1
     , alpm
     , tasty >=0.11 && <0.12
     , tasty-hunit >=0.9 && <0.10

--- a/alpm/package.yaml
+++ b/alpm/package.yaml
@@ -1,0 +1,18 @@
+name: alpm
+version: '0.1.0.0'
+author: Colin Woodbury
+maintainer: colingw@gmail.com
+license: BSD3
+
+ghc-options:
+  - -fwarn-unused-imports
+  - -fwarn-unused-binds
+
+dependencies:
+  - base >=4.9 && <4.10
+#  - bindings-DSL >= 1.0 && < 1.1
+
+library:
+  source-dirs: .
+  extra-libraries:
+    - alpm

--- a/alpm/package.yaml
+++ b/alpm/package.yaml
@@ -7,12 +7,14 @@ license: BSD3
 ghc-options:
   - -fwarn-unused-imports
   - -fwarn-unused-binds
+  - -fwarn-name-shadowing
+  - -fwarn-unused-matches
 
 dependencies:
   - base >= 4.8 && < 4.10
   - bindings-DSL >= 1.0 && < 1.1
   - text
-  - versions >= 3.0.1.1 && < 3.1
+  - versions >= 3.0.2.1 && < 3.1
 
 library:
   source-dirs: .

--- a/alpm/package.yaml
+++ b/alpm/package.yaml
@@ -14,7 +14,7 @@ dependencies:
   - base >= 4.8 && < 4.10
   - bindings-DSL >= 1.0 && < 1.1
   - text
-  - versions >= 3.0.2.1 && < 3.1
+  - versions >= 3.1.0.1 && < 3.2
 
 library:
   source-dirs: .

--- a/alpm/package.yaml
+++ b/alpm/package.yaml
@@ -10,9 +10,21 @@ ghc-options:
 
 dependencies:
   - base >=4.9 && <4.10
-#  - bindings-DSL >= 1.0 && < 1.1
+  - bindings-DSL >= 1.0 && < 1.1
+  - text
 
 library:
   source-dirs: .
   extra-libraries:
     - alpm
+
+tests:
+  alpm-test:
+    main: Test.hs
+    source-dirs: test
+    ghc-options:
+      - -threaded
+    dependencies:
+      - alpm
+      - tasty >=0.11 && <0.12
+      - tasty-hunit >=0.9 && <0.10

--- a/alpm/package.yaml
+++ b/alpm/package.yaml
@@ -1,5 +1,5 @@
 name: alpm
-version: '0.1.0.0'
+version: '1.0.0'
 author: Colin Woodbury
 maintainer: colingw@gmail.com
 license: BSD3
@@ -9,9 +9,10 @@ ghc-options:
   - -fwarn-unused-binds
 
 dependencies:
-  - base >=4.9 && <4.10
+  - base >= 4.8 && < 4.10
   - bindings-DSL >= 1.0 && < 1.1
   - text
+  - versions >= 3.0.1.1 && < 3.1
 
 library:
   source-dirs: .

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -32,5 +32,5 @@ initT = do
       rootPath h @?= "/"
       dbPath h @?= "/var/lib/pacman/"
       lockfile h @?= "/var/lib/pacman/db.lck"
-      release h >>= \res -> res @?= 0
+      close h >>= \res -> res @?= 0
     Left e  -> assertFailure $ unpack e

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Alpm
+
+---
+
+main :: IO ()
+main = defaultMain suite
+
+suite :: TestTree
+suite = testGroup "ALPM Bindings"
+  [ testGroup "Misc."
+    [ testCase "ALPM Version" $ alpmVersion @?= "10.0.1"
+    ]
+  ]

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Alpm
 import Data.Text (Text, unpack)
+import Data.Versions
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -15,7 +16,7 @@ main = defaultMain suite
 suite :: TestTree
 suite = testGroup "ALPM Bindings"
   [ testGroup "Misc."
-    [ testCase "ALPM Version" $ version @?= "10.0.1"
+    [ testCase "ALPM Version" $ alpmVersion @?= SemVer 10 0 1 [] []
     , testCase "Initialize Handler" initT
     ]
   ]

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -3,8 +3,12 @@
 module Main where
 
 import Alpm
+import Alpm.Internal.Package (alpm_pkg_vercmp)
+import Data.Monoid
 import Data.Text (Text, unpack)
 import Data.Versions
+import Foreign
+import Foreign.C.String
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -15,11 +19,18 @@ main = defaultMain suite
 
 suite :: TestTree
 suite = testGroup "ALPM Bindings"
-  [ testGroup "Misc."
+  [ testGroup "Packages"
+    [ testGroup "Version Comparisons (alpm_pkg_vercmp)" $ successive ++ pairs
+
+    ]
+  , testGroup "Misc."
     [ testCase "ALPM Version" $ alpmVersion @?= SemVer 10 0 1 [] []
     , testCase "Initialize Handler" initT
     ]
   ]
+  where successive = concatMap comparisons [ slnp, ml, wpr, wprml, mpri, ftmp ]
+        pairs = map (uncurry vercmpT) $ concat [ anv ]
+
 
 assertRight :: Either Text a -> Assertion
 assertRight (Left e) = assertFailure $ unpack e
@@ -35,3 +46,77 @@ initT = do
       lockfile h @?= "/var/lib/pacman/db.lck"
       close h >>= \res -> res @?= 0
     Left e  -> assertFailure $ unpack e
+
+comparisons :: [Text] -> [TestTree]
+comparisons vs = zipWith vercmpT vs $ tail vs
+
+-- TODO: Get alpm's unit tests for `alpm_pkg_ver` and use its samples. So far, it seems
+-- pretty brittle since it expects a certain package version layout.
+
+vercmpT :: Text -> Text -> TestTree
+vercmpT v0 v1 = testCase (unpack $ v0 <> " < " <> v1) $ do
+  v0' <- newCString $ unpack v0
+  v1' <- newCString $ unpack v1
+  let res = alpm_pkg_vercmp v0' v1'
+  res @?= (-1)
+  let l = fromRight (parseV v0)
+      r = fromRight (parseV v1)
+  if l < r
+    then pure ()
+    else assertFailure $ show l ++ "\n" ++ show r
+  free v0' >> free v1'  -- Release allocated memory.
+
+-- Borrowed from `Data.Versions` tests.
+
+semverOrd :: [Text]
+semverOrd = [ "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta"
+            , "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1"
+            , "1.0.0"
+            ]
+
+cabalOrd :: [Text]
+cabalOrd = [ "0.2", "0.2.0", "0.2.0.0" ]
+
+versionOrd :: [Text]
+versionOrd = [ "0.9.9.9", "1.0.0.0", "1.0.0.1", "2" ]
+
+messOrd :: [Text]
+messOrd = [ "10.2+0.93+1-1", "10.2+0.93+1-2", "10.2+0.93+2-1"
+          , "10.2+0.94+1-1", "10.3+0.93+1-1", "11.2+0.93+1-1", "12" ]
+
+-- Borrowed from https://git.archlinux.org/pacman.git/tree/test/util/vercmptest.sh
+
+-- | Similar length, no pkgrel
+slnp :: [Text]
+slnp = [ "1.5.0", "1.5.1" ]
+
+-- | Mixed length
+ml :: [Text]
+ml = [ "1.5", "1.5.1" ]
+
+-- | With pkgrel
+wpr :: [Text]
+wpr = [ "1.5.0-1", "1.5.0-2", "1.5.1-1" ]
+
+-- | With pkgrel, mixed length
+wprml :: [Text]
+wprml = [ "1.5-1", "1.5.1-1", "1.6-1" ]
+
+-- | Mixed pkgrel inclusion
+mpri :: [Text]
+mpri = [ "1.0-1", "1.1" ]
+
+-- | Alphanumeric versions
+anv :: [(Text, Text)]
+anv = [ ("1.5b-1", "1.5-1")
+      , ("1.5b", "1.5")
+      , ("1.5b-1", "1.5")
+      , ("1.5b", "1.5.1")
+      ]
+
+-- | From the manpage (apparently).
+ftmp :: [Text]
+ftmp = [ "1.0a", "1.0alpha", "1.0b", "1.0beta", "1.0rc", "1.0" ]
+
+fromRight :: Either t t1 -> t1
+fromRight (Right a) = a

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -29,7 +29,7 @@ suite = testGroup "ALPM Bindings"
     ]
   ]
   where successive = concatMap comparisons [ slnp, ml, wpr, wprml, mpri, ftmp ]
-        pairs = map (uncurry vercmpT) $ concat [ anv ]
+        pairs = map (uncurry vercmpT) $ concat [ anv, adv ]
 
 
 assertRight :: Either Text a -> Assertion
@@ -117,6 +117,13 @@ anv = [ ("1.5b-1", "1.5-1")
 -- | From the manpage (apparently).
 ftmp :: [Text]
 ftmp = [ "1.0a", "1.0alpha", "1.0b", "1.0beta", "1.0rc", "1.0" ]
+
+-- | Alpha-dotted versions
+adv :: [(Text, Text)]
+adv = [ ("1.5", "1.5.a")
+      , ("1.5.a", "1.5.b")
+      , ("1.5.b", "1.5.1")
+      ]
 
 fromRight :: Either t t1 -> t1
 fromRight (Right a) = a

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Alpm
 import Alpm.Internal.Package (alpm_pkg_vercmp)
+import Alpm.Internal.Enums
 import Data.Monoid
 import Data.Text (Text, unpack)
 import Data.Versions
@@ -21,10 +22,12 @@ suite :: TestTree
 suite = testGroup "ALPM Bindings"
   [ testGroup "Packages"
     [ testGroup "Version Comparisons (alpm_pkg_vercmp)" $ successive ++ pairs
-
+    ]
+  , testGroup "Enums"
+    [ testCase "validations" validationsT
     ]
   , testGroup "Misc."
-    [ testCase "ALPM Version" $ alpmVersion @?= SemVer 10 0 1 [] []
+    [ testCase "ALPM Version" $ alpmVersion @?= SemVer 10 0 2 [] []
     , testCase "Initialize Handler" initT
     ]
   ]
@@ -47,11 +50,12 @@ initT = do
       close h >>= \res -> res @?= 0
     Left e  -> assertFailure $ unpack e
 
+validationsT :: Assertion
+validationsT = validations (mconcat xs) @?= xs
+  where xs = [vm_none, vm_md5, vm_sha256, vm_sig ]
+
 comparisons :: [Text] -> [TestTree]
 comparisons vs = zipWith vercmpT vs $ tail vs
-
--- TODO: Get alpm's unit tests for `alpm_pkg_ver` and use its samples. So far, it seems
--- pretty brittle since it expects a certain package version layout.
 
 vercmpT :: Text -> Text -> TestTree
 vercmpT v0 v1 = testCase (unpack $ v0 <> " < " <> v1) $ do

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -25,6 +25,7 @@ suite = testGroup "ALPM Bindings"
     ]
   , testGroup "Enums"
     [ testCase "validations" validationsT
+    , testCase "siglevels" siglevelsT
     ]
   , testGroup "Misc."
     [ testCase "ALPM Version" $ alpmVersion @?= SemVer 10 0 2 [] []
@@ -53,6 +54,11 @@ initT = do
 validationsT :: Assertion
 validationsT = validations (mconcat xs) @?= xs
   where xs = [vm_none, vm_md5, vm_sha256, vm_sig ]
+
+siglevelsT :: Assertion
+siglevelsT = siglevels (mconcat xs) @?= xs
+  where xs = [ sl_package, sl_pkg_optional, sl_pkg_marginal, sl_pkg_unknown
+             , sl_database, sl_db_optional , sl_db_marginal, sl_db_unknown, sl_default ]
 
 comparisons :: [Text] -> [TestTree]
 comparisons vs = zipWith vercmpT vs $ tail vs

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -2,10 +2,10 @@
 
 module Main where
 
-import Test.Tasty
-import Test.Tasty.HUnit
 import Alpm
 import Data.Text (Text, unpack)
+import Test.Tasty
+import Test.Tasty.HUnit
 
 ---
 
@@ -28,5 +28,9 @@ initT :: Assertion
 initT = do
   handle <- initialize "/" "/var/lib/pacman/"
   case handle of
-    Right h -> alpm_release h >>= \res -> res @?= 0
+    Right h -> do
+      rootPath h @?= "/"
+      dbPath h @?= "/var/lib/pacman/"
+      lockfile h @?= "/var/lib/pacman/db.lck"
+      release h >>= \res -> res @?= 0
     Left e  -> assertFailure $ unpack e

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -5,6 +5,7 @@ module Main where
 import Test.Tasty
 import Test.Tasty.HUnit
 import Alpm
+import Data.Text (Text, unpack)
 
 ---
 
@@ -14,6 +15,18 @@ main = defaultMain suite
 suite :: TestTree
 suite = testGroup "ALPM Bindings"
   [ testGroup "Misc."
-    [ testCase "ALPM Version" $ alpmVersion @?= "10.0.1"
+    [ testCase "ALPM Version" $ version @?= "10.0.1"
+    , testCase "Initialize Handler" initT
     ]
   ]
+
+assertRight :: Either Text a -> Assertion
+assertRight (Left e) = assertFailure $ unpack e
+assertRight (Right _) = pure ()
+
+initT :: Assertion
+initT = do
+  handle <- initialize "/" "/var/lib/pacman/"
+  case handle of
+    Right h -> alpm_release h >>= \res -> res @?= 0
+    Left e  -> assertFailure $ unpack e

--- a/alpm/test/Test.hs
+++ b/alpm/test/Test.hs
@@ -28,8 +28,8 @@ suite = testGroup "ALPM Bindings"
     , testCase "Initialize Handler" initT
     ]
   ]
-  where successive = concatMap comparisons [ slnp, ml, wpr, wprml, mpri, ftmp ]
-        pairs = map (uncurry vercmpT) $ concat [ anv, adv ]
+  where successive = concatMap comparisons [ slnp, ml, wpr, wprml, mpri, ftmp, adad ]
+        pairs = map (uncurry vercmpT) $ concat [ anv, adv, epochs, eoo, espp ]
 
 
 assertRight :: Either Text a -> Assertion
@@ -65,24 +65,6 @@ vercmpT v0 v1 = testCase (unpack $ v0 <> " < " <> v1) $ do
     then pure ()
     else assertFailure $ show l ++ "\n" ++ show r
   free v0' >> free v1'  -- Release allocated memory.
-
--- Borrowed from `Data.Versions` tests.
-
-semverOrd :: [Text]
-semverOrd = [ "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta"
-            , "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1"
-            , "1.0.0"
-            ]
-
-cabalOrd :: [Text]
-cabalOrd = [ "0.2", "0.2.0", "0.2.0.0" ]
-
-versionOrd :: [Text]
-versionOrd = [ "0.9.9.9", "1.0.0.0", "1.0.0.1", "2" ]
-
-messOrd :: [Text]
-messOrd = [ "10.2+0.93+1-1", "10.2+0.93+1-2", "10.2+0.93+2-1"
-          , "10.2+0.94+1-1", "10.3+0.93+1-1", "11.2+0.93+1-1", "12" ]
 
 -- Borrowed from https://git.archlinux.org/pacman.git/tree/test/util/vercmptest.sh
 
@@ -123,6 +105,31 @@ adv :: [(Text, Text)]
 adv = [ ("1.5", "1.5.a")
       , ("1.5.a", "1.5.b")
       , ("1.5.b", "1.5.1")
+      , ("2.0a", "2.0.a")
+      ]
+
+-- | Alpha dots and dashes
+adad :: [Text]
+adad = [ "1.5-1", "1.5.b" ]
+
+epochs :: [(Text, Text)]
+epochs = [ ("0:1.0", "0:1.1")
+         , ("1:1.0", "2:1.1")
+         ]
+
+-- | Epoch + sometimes present pkgrel
+espp :: [(Text, Text)]
+espp = [ ("0:1.0-1", "1:1.0")
+       , ("0:1.1-1", "1:1.0-1")
+       ]
+
+-- | Epoch included on one version.
+eoo :: [(Text, Text)]
+eoo = [ ("0:1.0", "1.1")
+      , ("1.0", "0:1.1")
+      , ("1.0", "1:1.0")
+      , ("1.1", "1:1.0")
+      , ("1.1", "1:1.1")
       ]
 
 fromRight :: Either t t1 -> t1

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
   - aura/
   - aur/
   - arel/
+  - alpm/
 
 extra-deps: []
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-8.18
 
 packages:
   - aura/
@@ -7,6 +7,6 @@ packages:
   - alpm/
 
 extra-deps:
-  - versions-3.0.2.1
+  - versions-3.1.0.1
 
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.13
+resolver: lts-8.15
 
 packages:
   - aura/
@@ -7,6 +7,6 @@ packages:
   - alpm/
 
 extra-deps:
-  - versions-3.0.1.1
+  - versions-3.0.2.1
 
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
   - arel/
   - alpm/
 
-extra-deps: []
+extra-deps:
+  - versions-3.0.1.1
 
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,6 @@ packages:
   - alpm/
 
 extra-deps:
-  - versions-3.1.0.1
+  - versions-3.1.1
 
 flags: {}


### PR DESCRIPTION
### TODO

- [x] Minimal bindings to `alpm_list`
- [ ] Enums
- [ ] Bindings for structs
- [ ] Bindings for `db` functions
- [ ] Bindings for `pkg` functions
- [ ] Bindings for `transaction` functions
- [ ] ...
- [ ] Fix Travis (missing `alpm.h`)

### Motivation

Aura 2 has been a long time coming. The starting point for this has always been writing the ALPM bindings,  which I have had a few false starts on. I've been at my new job for a year, and my schedule has settled to the point where I can finally begin this in earnest. Thanks to everyone for their patience.

The path forward is clear, and the main benefits to direct ALPM bindings are:

- Much faster package DB lookups
- No more reliance on calling `pacman` manually through shell calls
- Complete control over the build process / package info output

### FAQ

> What about Aura 1.4?
 
This may not have a reason to continue, despite the work that has been put into it. I feel like starting from scratch with both `alpm` and `freer-effects` in mind from the get-go will produce a *much* cleaner Aura.

> Seems like you're writing the bindings by hand.

I am. I surveyed the FFI landscape, where it seemed like `c2hsc` is the best option around. While a good option, I think it's overkill. We can produce cleaner low-level bindings ourselves that don't even need foreign imports to every function available (particularly in `alpm_list`). That, and that the dev process isn't as nice when dealing with `.hsc` files.

> What about Nix? 

Nix is probably the future of package management. That said, Arch is Arch, and pacman (alpm) is entrenched. Arch is healthy and will be long-lived, and will always need a good bridge to the AUR. `pacman` can be improved upon (concurrent builds!), and that is where Aura will shine.