### PR TITLE
Fix language names

### DIFF
--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -85,12 +85,12 @@ languageNames = Map.fromList . zip [ Japanese, Polish, Croatian, Swedish, German
     Spanish    -> [ "Japanese", "Polaco", "Croata", "Sueco", "Alemán", "Español", "Portugués", "Francés", "Ruso", "Italiano", "Serbio", "Noruego", "Indonesio", "Chinese" ]
     Portuguese -> [ "Japonês", "Polonês", "Croata", "Sueco", "Alemão", "Espanhol", "Português", "Francês", "Russo", "Italiano", "Sérvio", "Norueguês", "Indonésio", "Chinês" ]
     French     -> [ "Japanese", "Polonais", "Croate", "Suédois", "Allemand", "Espagnol", "Portugais", "Français", "Russe", "Italien", "Serbe", "Norvégien", "Indonesian", "Chinese" ]
-    Russian    -> [ "Japanese", "Польский", "Хорватский", "Шведский", "Немецкий", "Испанский", "Португальский", "Французский", "Русский", "Итальянский", "Сербский", "Норвежский", "Индонезийский", "Chinese" ]
+    Russian    -> [ "Японский", "Польский", "Хорватский", "Шведский", "Немецкий", "Испанский", "Португальский", "Французский", "Русский", "Итальянский", "Сербский", "Норвежский", "Индонезийский", "Китайский" ]
     Italian    -> [ "Giapponese", "Polacco", "Croato", "Svedese", "Tedesco", "Spagnolo", "Portoghese", "Francese", "Russo", "Italiano", "", "", "Indonesian", "Chinese" ]
     Serbian    -> [ "Japanese", "Пољски", "Хрватски", "Шведски", "Немачки", "Шпански", "Португалски", "Француски", "Руски", "Италијански", "Српски", "", "Indonesian", "Chinese" ]
     Norwegian  -> [ "Japanese", "Polsk", "Kroatisk", "Svensk", "Tysk", "Spansk", "Portugisisk", "Fransk", "Russisk", "Italiensk", "Serbisk", "Norsk", "Indonesian", "Chinese" ]
     Indonesia  -> [ "Japanese", "Polandia", "Kroasia", "Swedia", "Jerman", "Spanyol", "Portugis", "Prancis", "Rusia", "Italia", "Serbia", "Norwegia", "Indonesian", "Chinese" ]
-    Chinese    -> [ "Japanese", "波兰语", "克罗地亚语", "瑞典语", "德语", "西班牙语", "葡萄牙语", "法语", "俄语", "意大利语", "塞尔维亚语", "挪威语", "印度尼西亚语", "中文" ]
+    Chinese    -> [ "日语", "波兰语", "克罗地亚语", "瑞典语", "德语", "西班牙语", "葡萄牙语", "法语", "俄语", "意大利语", "塞尔维亚语", "挪威语", "印度尼西亚语", "中文" ]
     _          -> [ "Japanese", "Polish", "Croatian", "Swedish", "German", "Spanish", "Portuguese", "French", "Russian", "Italian", "Serbian", "Norwegian", "Indonesian", "Chinese" ]
 
 translatorMsgTitle :: Language -> T.Text
@@ -171,6 +171,7 @@ trueRoot_3 = \case
     German     -> "Seit makepkg v4.2 ist es nicht mehr möglich als root zu bauen."
     Spanish    -> "Desde makepkg v4.2 no es posible compilar paquetes como root."
     Portuguese -> "A partir da versão v4.2 de makepkg, não é mais possível compilar como root."
+    Russian    -> "С версии makepkg v4.2 сборка от имени root более невозможна."
     Chinese    -> "自从 makepkg v4.2 以后，就不能以根用户身份构建软件了。"
     Swedish    -> "I makepkg v4.2 och uppåt är det inte tillåtet att bygga som root."
     _          -> "As of makepkg v4.2, building as root is no longer possible."
@@ -286,6 +287,7 @@ buildFail_8 :: Language -> Doc AnsiStyle
 buildFail_8 = \case
     Japanese   -> "makepkgは失敗しました。"
     Portuguese -> "Ocorreu um erro ao executar makepkg"
+    Russian    -> "Произошла ошибка makepkg."
     _          -> "There was a makepkg failure."
 
 ------------------------------
@@ -336,11 +338,15 @@ depError _ (VerConflict s) = s
 depError _ (Ignored s)     = s
 depError l (NonExistant s) = case l of
   Portuguese -> "A dependência " <> bt s <> " não foi encontrada."
+  Russian    -> "Зависимость " <> bt s <> " не найдена."
   _          -> "The dependency " <> bt s <> " couldn't be found."
 depError l (UnparsableVersion s) = case l of
   Portuguese -> "A versão de " <> bt s <> " não pôde ser interpretada."
+  Russian    -> "Версия для " <> bt s <> " не распознана."
   _          -> "The version number for " <> bt s <> " couldn't be parsed."
-depError _ (BrokenProvides pkg pro name) = "The package " <> bt pkg <> " needs " <> bt name <> ", which provides " <> bt pro <> "."
+depError l (BrokenProvides pkg pro name) = case l of
+  Russian    -> "Пакету " <> bt pkg <> " требуется " <> bt name <> ", предоставляющий " <> bt pro <> "."
+  _          -> "The package " <> bt pkg <> " needs " <> bt name <> ", which provides " <> bt pro <> "."
 
 -----------------
 -- aura functions

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -65,7 +65,7 @@ translators = Map.fromList
     , (Spanish,    "Alejandro Gómez / Sergio Conde")
     , (Portuguese, "Henry Kupty / Thiago Perrotta / Wagner Amaral")
     , (French,     "Ma Jiehong / Fabien Dubosson")
-    , (Russian,    "Kyrylo Silin")
+    , (Russian,    "Kyrylo Silin / Alexey Kotlyarov")
     , (Italian,    "Bob Valantin")
     , (Serbian,    "Filip Brcic")
     , (Norwegian,  "\"chinatsun\"")
@@ -747,22 +747,22 @@ removeMakeDepsAfter_1 = \case
 ----------------------------
 -- NEEDS TRANSLATION
 cleanStates_2 :: Int -> Language -> Doc AnsiStyle
-cleanStates_2 (bt . T.pack . show -> n) = \case
-    Japanese   -> n <> "個のパッケージ状態記録だけが残される。その他削除？"
-    Polish     -> n <> " stan pakietów zostanie zachowany. Usunąć resztę?"
-    Croatian   -> n <> " stanja paketa će biti zadržano. Ukloniti ostatak?"
-    German     -> n <> " Paketzustände werden behalten. Den Rest entfernen?"
-    Spanish    -> "El estado del paquete" <> n <> " se mantendrá. ¿Deseas eliminar el resto?"
-    Serbian    -> n <> " стања пакета ће бити сачувано. Уклонити остатак?"
-    Norwegian  -> n <> " pakketilstander vil bli beholdt. Vil du fjerne resten?"
-    Italian    -> n <> " lo stato dei pacchetti sarà mantenuto. Rimuovere i rimanenti?"
-    Portuguese -> n <> " estados de pacotes serão mantidos. Remover o resto?"
-    French     -> n <> " états des paquets vont être conservés. Supprimer le reste ?"
-    Russian    -> n <> " -- столько состояний пакетов будут оставлены. Удалить оставшиеся?"
-    Indonesia  -> n <> " paket akan tetap sama. Hapus yang lainnya?"
-    Chinese    -> n <> " 个包的状态将会保留。删除其它的？"
-    Swedish    -> n <> " paket kommer att bevaras. Ta bort resten?"
-    _          -> n <> " package states will be kept. Remove the rest?"
+cleanStates_2 n@(bt . T.pack . show -> s) = \case
+    Japanese   -> s <> "個のパッケージ状態記録だけが残される。その他削除？"
+    Polish     -> s <> " stan pakietów zostanie zachowany. Usunąć resztę?"
+    Croatian   -> s <> " stanja paketa će biti zadržano. Ukloniti ostatak?"
+    German     -> s <> " Paketzustände werden behalten. Den Rest entfernen?"
+    Spanish    -> "El estado del paquete" <> s <> " se mantendrá. ¿Deseas eliminar el resto?"
+    Serbian    -> s <> " стања пакета ће бити сачувано. Уклонити остатак?"
+    Norwegian  -> s <> " pakketilstander vil bli beholdt. Vil du fjerne resten?"
+    Italian    -> s <> " lo stato dei pacchetti sarà mantenuto. Rimuovere i rimanenti?"
+    Portuguese -> s <> " estados de pacotes serão mantidos. Remover o resto?"
+    French     -> s <> " états des paquets vont être conservés. Supprimer le reste ?"
+    Russian    -> s <> (pluralRussian " состояние пакетов будет оставлено." " состояния пакетов будут оставлены." " состояний пакетов будет оставлено." n) <> " Удалить оставшиеся?"
+    Indonesia  -> s <> " paket akan tetap sama. Hapus yang lainnya?"
+    Chinese    -> s <> " 个包的状态将会保留。删除其它的？"
+    Swedish    -> s <> " paket kommer att bevaras. Ta bort resten?"
+    _          -> s <> " package states will be kept. Remove the rest?"
 
 -- NEEDS TRANSLATION
 cleanStates_3 :: Language -> Doc AnsiStyle
@@ -786,16 +786,19 @@ cleanStates_3 = \case
 cleanStates_4 :: Int -> Language -> Doc AnsiStyle
 cleanStates_4 n = \case
   Japanese -> "現在のパッケージ状態記録：" <> pretty n <> "個。"
+  Russian  -> "У вас сейчас " <+> pretty n <+> (pluralRussian " сохраненное состояние пакета" " сохраненных состояний пакета" " сохраненных состояний пакетов." n)
   _        -> "You currently have" <+> pretty n <+> "saved package states."
 
 cleanStates_5 :: T.Text -> Language -> Doc AnsiStyle
 cleanStates_5 t = \case
   Japanese -> "一番最近に保存されたのは：" <> pretty t
+  Russian  -> "Последнее сохраненное:" <+> pretty t
   _        -> "Mostly recently saved:" <+> pretty t
 
 readState_1 :: Language -> Doc AnsiStyle
 readState_1 = \case
     Portuguese -> "O arquivo de estado não pôde ser interpretado. É um arquivo JSON válido?"
+    Russian    -> "Это состояние не распознано. Это корректный JSON?"
     _          -> "That state file failed to parse. Is it legal JSON?"
 
 ----------------------------
@@ -964,22 +967,22 @@ cleanCache_2 = \case
     _          -> "This will delete the ENTIRE package cache."
 
 cleanCache_3 :: Word -> Language -> Doc AnsiStyle
-cleanCache_3 (bt . T.pack . show -> n) = \case
-    Japanese   -> "パッケージ・ファイルは" <> n <> "個保存されます。"
-    Polish     -> n <> " wersji każdego pakietu zostanie zachowane."
-    Croatian   -> n <> " zadnjih verzija svakog paketa će biti zadržano."
-    Swedish    -> n <> " av varje paketfil kommer att sparas."
-    German     -> n <> " jeder Paketdatei wird behalten."
-    Spanish    -> "Se mantendrán " <> n <> " ficheros de cada paquete."
-    Portuguese -> n <> " arquivos de cada pacote serão mantidos."
-    French     -> n <> " fichiers de chaque paquet sera conservé."
-    Russian    -> n <> " версии каждого пакета будут нетронуты."
-    Italian    -> n <> " di ciascun pacchetto sarà mantenuto."
-    Serbian    -> n <> " верзије сваког од пакета ће бити сачуване."
-    Norwegian  -> n <> " av hver pakkefil blir beholdt."
-    Indonesia  -> n <> " berkas dari tiap paket akan disimpan."
-    Chinese    -> "每个包文件将会保存 " <> n <> " 个版本。"
-    _          -> n <> " of each package file will be kept."
+cleanCache_3 n@(bt . T.pack . show -> s) = \case
+    Japanese   -> "パッケージ・ファイルは" <> s <> "個保存されます。"
+    Polish     -> s <> " wersji każdego pakietu zostanie zachowane."
+    Croatian   -> s <> " zadnjih verzija svakog paketa će biti zadržano."
+    Swedish    -> s <> " av varje paketfil kommer att sparas."
+    German     -> s <> " jeder Paketdatei wird behalten."
+    Spanish    -> "Se mantendrán " <> s <> " ficheros de cada paquete."
+    Portuguese -> s <> " arquivos de cada pacote serão mantidos."
+    French     -> s <> " fichiers de chaque paquet sera conservé."
+    Russian    -> s <> pluralRussian " версия каждого пакета будет нетронута." " версии каждого пакета будут нетронуты." " версий каждого пакета будут нетронуты." n
+    Italian    -> s <> " di ciascun pacchetto sarà mantenuto."
+    Serbian    -> s <> " верзије сваког од пакета ће бити сачуване."
+    Norwegian  -> s <> " av hver pakkefil blir beholdt."
+    Indonesia  -> s <> " berkas dari tiap paket akan disimpan."
+    Chinese    -> "每个包文件将会保存 " <> s <> " 个版本。"
+    _          -> s <> " of each package file will be kept."
 
 cleanCache_4 :: Language -> Doc AnsiStyle
 cleanCache_4 = \case
@@ -1055,7 +1058,7 @@ cleanNotSaved_1 = \case
 
 -- NEEDS TRANSLATION
 cleanNotSaved_2 :: Int -> Language -> Doc AnsiStyle
-cleanNotSaved_2 (cyan . pretty -> s) = \case
+cleanNotSaved_2 n@(cyan . pretty -> s) = \case
     Japanese   -> "「" <> s <> "」の不要パッケージファイルがあります。削除しますか？"
     Polish     -> s <> " niepotrzebnych plików zostało znalezionych. Usunąć?"
     Croatian   -> s <> " nepotrebnih datoteka pronađeno. Obrisati?"
@@ -1065,7 +1068,7 @@ cleanNotSaved_2 (cyan . pretty -> s) = \case
     Italian    -> s <> " pacchetti non necessari trovati. Cancellarli?"
     Portuguese -> s <> " pacotes não necessários encontrados. Removê-los?"
     French     -> s <> " paquets inutiles trouvés. Les supprimer ?"
-    Russian    -> s <> " -- столько ненужных пакетных файлов обнаружено. Удалить?"
+    Russian    -> pluralRussian ("Обнаружен " <> s <> " ненужный файл пакета.") ("Обнаружены " <> s <> " ненужных файла пакетов.") ("Обнаружено " <> s <> " ненужных файлов пакетов.") n <> " Удалить?"
     Indonesia  -> s <> " berkas paket yang tidak dibutuhkan ditemukan. Hapus?"
     Chinese    -> "发现了 " <> s <> " 个不需要的包文件。是否删除？"
     Swedish    -> s <> " oanvända paket hittades. Ta bort?"
@@ -1214,6 +1217,7 @@ restoreState_2 :: Language -> Doc AnsiStyle
 restoreState_2 = \case
     Japanese   -> "保存されたパッケージ状態がない。作るには「-B」を。"
     Portuguese -> "Nenhum estado disponível para ser recuperado. (Utilize -B para salvar o estado atual)"
+    Russian    -> "Нет сохраненных состояний для восстановления. (Используйте -B для сохранения текущего состояния)"
     Chinese    -> "没有要恢复的已保存状态。（使用 -B 保存当前状态）"
     Swedish    -> "Inga sparade tillstånd att återhämta. (Använd -B för att spara det nuvarande tillståndet)"
     _          -> "No saved states to be restored. (Use -B to save the current state)"
@@ -1243,6 +1247,7 @@ reinstallAndRemove_1 = \case
 whoIsBuildUser_1 :: Language -> Doc AnsiStyle
 whoIsBuildUser_1 = \case
     Portuguese -> "Não foi possível determinal o usuário que executará a compilação."
+    Russian    -> "Не удается определить, от имени какого пользователя производить сборку."
     _          -> "Can't determine which user account to build with."
 
 ------------------------
@@ -1270,6 +1275,7 @@ pacmanFailure_1 = \case
 confParsing_1 :: Language -> Doc AnsiStyle
 confParsing_1 = \case
     Portuguese -> "Não foi possível interpretar o arquivo pacman.conf ."
+    Russian    -> "Не удается распознать формат вашего файла pacman.conf."
     _          -> "Unable to parse your pacman.conf file."
 
 provides_1 :: T.Text -> Doc AnsiStyle
@@ -1327,6 +1333,7 @@ yesNoMessage = \case
     Italian    -> "[S/n]"
     Portuguese -> "[S/n]"
     French     -> "[O/n]"
+    Russian    -> "[Д/н]"
     _          -> "[Y/n]"
 
 yesPattern :: Language -> [T.Text]
@@ -1339,4 +1346,13 @@ yesPattern = \case
     Italian    -> ["s", "si"]
     Portuguese -> ["s", "sim"]
     French     -> ["o", "oui"]
+    Russian    -> ["д", "да"]
     _          -> ["y", "yes"]
+
+----------------------
+-- Pluralization rules
+----------------------
+pluralRussian :: Integral n => a -> a -> a -> n -> a
+pluralRussian singular plural1 plural2 n | n % 10 == 1 && n % 100 /= 11 = singular
+                                         | n % 10 `elem` [2, 3, 4] = plural1
+                                         | otherwise = plural2

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -85,7 +85,7 @@ languageNames = Map.fromList . zip [ Japanese, Polish, Croatian, Swedish, German
     Spanish    -> [ "Japanese", "Polaco", "Croata", "Sueco", "Alemán", "Español", "Portugués", "Francés", "Ruso", "Italiano", "Serbio", "Noruego", "Indonesio", "Chinese" ]
     Portuguese -> [ "Japonês", "Polonês", "Croata", "Sueco", "Alemão", "Espanhol", "Português", "Francês", "Russo", "Italiano", "Sérvio", "Norueguês", "Indonésio", "Chinês" ]
     French     -> [ "Japanese", "Polonais", "Croate", "Suédois", "Allemand", "Espagnol", "Portugais", "Français", "Russe", "Italien", "Serbe", "Norvégien", "Indonesian", "Chinese" ]
-    Russian    -> [ "Japanese", "Польский", "Хорватский", "Шведский", "Немецкий", "Испанский", "Португальский", "Русский", "Итальянский", "Сербский", "Норвежский", "Индонезийский", "Chinese" ]
+    Russian    -> [ "Japanese", "Польский", "Хорватский", "Шведский", "Немецкий", "Испанский", "Португальский", "Французский", "Русский", "Итальянский", "Сербский", "Норвежский", "Индонезийский", "Chinese" ]
     Italian    -> [ "Giapponese", "Polacco", "Croato", "Svedese", "Tedesco", "Spagnolo", "Portoghese", "Francese", "Russo", "Italiano", "", "", "Indonesian", "Chinese" ]
     Serbian    -> [ "Japanese", "Пољски", "Хрватски", "Шведски", "Немачки", "Шпански", "Португалски", "Француски", "Руски", "Италијански", "Српски", "", "Indonesian", "Chinese" ]
     Norwegian  -> [ "Japanese", "Polsk", "Kroatisk", "Svensk", "Tysk", "Spansk", "Portugisisk", "Fransk", "Russisk", "Italiensk", "Serbisk", "Norsk", "Indonesian", "Chinese" ]

--- a/aura/lib/Aura/Types.hs
+++ b/aura/lib/Aura/Types.hs
@@ -194,7 +194,7 @@ data Language = English
               | Norwegian
               | Indonesia
               | Chinese
-                deriving (Eq, Enum, Ord, Show)
+                deriving (Eq, Enum, Bounded, Ord, Show)
 
 data DepError = NonExistant T.Text
               | VerConflict (Doc AnsiStyle)

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -2,6 +2,7 @@
 
 module Main ( main ) where
 
+import           Aura.Languages
 import           Aura.Packages.Repository
 import           Aura.Pacman
 import           Aura.Types
@@ -47,6 +48,16 @@ suite conf = testGroup "Unit Tests"
         let p = parse config "pacman.conf" conf
             r = either (const Nothing) (\(Config c) -> Just c) p >>= M.lookup "HoldPkg"
         r @?= Just ["pacman", "glibc"]
+    ]
+  , testGroup "Aura.Languages"
+    [ testCase "Language names are complete" $ do
+        case [minBound..maxBound] :: [Language] of
+          [] -> assertFailure "No languages found"
+          lang:restOfLangs -> do
+            let names = languageNames lang
+            for_ restOfLangs $ \otherLang -> do
+              let otherNames = languageNames otherLang
+              assertEqual ("Language name maps for " ++ show lang ++ " and " ++ show otherLang ++ " have different size") (M.size names) (M.size otherNames)
     ]
   ]
 


### PR DESCRIPTION
`languageNames` was updated sloppily at some point in the past - it has less language names for one of the languages. I've added a test so that doesn't repeat in the future and added the missing value.

```shell
$ LANG=ru stack exec aura -- --version
                       
 __ _ _  _ _ _ __ _    Pacman v5.1.0 - libalpm v11.0.0
/ _` | || | '_/ _` |   Copyright (C) 2006-2018 Pacman Development Team
\__,_|\_,_|_| \__,_|   Copyright (C) 2002-2006 Judd Vinet
AURA Version 1.4.0     
 by Colin Woodbury     This program may be freely redistributed under
                       the terms of the GNU General Public License.
Переводчики Aura:      
 Chris "Kwpolska" Warrick (Польский)
 Denis Kasak / "stranac" (Хорватский)
 Fredrik Haikarainen / Daniel Beecham (Шведский)
 Lukas Niederbremer / Jonas Platte (Немецкий)
 Alejandro Gómez / Sergio Conde (Испанский)
 Henry "Ingvij" Kupty / Thiago "thiagowfx" Perrotta (Португальский)
 Ma Jiehong / Fabien Dubosson (Русский) (*)
 Kyrylo Silin (Итальянский)
 Bob Valantin (Сербский)
 Filip Brcic (Норвежский)
 "chinatsun" (Индонезийский)
 "pak tua Greg" (Chinese)
aura: Map.!: given key is not an element in the map
CallStack (from HasCallStack):
  error, called at libraries/containers/Data/Map/Base.hs:489:16 in containers-0.5.7.1:Data.Map.Base
```

Also, I've started updating some of the translations - if you'd like, I'll do that as a separate PR with a complete update (of what I speak).