### PR TITLE
README.md: fix typo "privileges"

### DIFF
--- a/aura/README.md
+++ b/aura/README.md
@@ -36,7 +36,7 @@ Install order is as follows:
   That said, a built package can't be handed off to pacman and installed
   if you _don't_ run as root. Other AUR helpers ignore this problem,
   but Aura does not. Even when run with `sudo`, packages are built
-  with normal user privilages, then handed to pacman and installed as root.
+  with normal user privileges, then handed to pacman and installed as root.
 
 ### Know your System
   Editing PKGBUILDs mid-build is not default behaviour.


### PR DESCRIPTION
https://www.merriam-webster.com/dictionary/privilege

Note that the README also mentions
>Built AUR package files are moved to the package cache. This allows for them to be easily downgraded when problems arise. Other top AUR helper programs do not do this

which is false; at least aurutils moves everything to a local repo in `/var/cache/pacman/<something>`. I left this for a different commit, though.