### PR TITLE
Factor out throttled concurrency logic

### DIFF
--- a/aura/lib/Aura/Concurrency.hs
+++ b/aura/lib/Aura/Concurrency.hs
@@ -1,0 +1,58 @@
+-- |
+-- Module    : Aura.Concurrency
+-- Copyright : (c) Colin Woodbury, 2012 - 2018
+-- License   : GPL3
+-- Maintainer: Colin Woodbury <colin@fosskers.ca>
+--
+-- Handle concurrent fetches from a `TQueue`, throttled by the number
+-- of CPUs that the user has available.
+
+module Aura.Concurrency ( throttled ) where
+
+import BasePrelude
+import Control.Concurrent.Async
+import Control.Concurrent.STM.TQueue
+import Control.Concurrent.STM.TVar
+
+---
+
+data Pool a b = Pool { threads :: Word
+                     , waiters :: TVar Word
+                     , source  :: TQueue a
+                     , target  :: TQueue b }
+
+newPool :: Foldable f => f a -> IO (Pool a b)
+newPool xs = Pool
+  <$> (fromIntegral <$> getNumCapabilities)
+  <*> newTVarIO 0
+  <*> atomically (newTQueue >>= \q -> traverse_ (writeTQueue q) xs $> q)
+  <*> atomically newTQueue
+
+data Status = Waiting | Working
+
+-- | Concurrently traverse over some `Foldable` using 1 thread per
+-- CPU that the user has.
+throttled :: Foldable f => (TQueue a -> a -> IO b) -> f a -> IO [b]
+throttled f xs = do
+  pool <- newPool xs
+  replicateConcurrently_ (fromIntegral $ threads pool) (work pool Working)
+  atomically . flushTQueue $ target pool
+  where work pool s = do
+          mx <- atomically . tryReadTQueue $ source pool
+          ws <- atomically . readTVar $ waiters pool
+          case (mx, s) of
+            (Nothing, Waiting) | ws == threads pool -> pure ()  -- All our threads have completed.
+                               | otherwise -> threadDelay 500000 *> work pool Waiting
+            (Nothing, Working) -> do
+              atomically (modifyTVar' (waiters pool) succ)
+              threadDelay 500000
+              work pool Waiting
+            (Just x, Waiting) -> do
+              atomically $ modifyTVar' (waiters pool) pred
+              b <- f (source pool) x
+              atomically $ writeTQueue (target pool) b
+              work pool Working
+            (Just x, Working) -> do
+              b <- f (source pool) x
+              atomically $ writeTQueue (target pool) b
+              work pool Working

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.2
+resolver: lts-12.4
 
 packages:
   - aura/


### PR DESCRIPTION
The PR provides the `throttled` function, which will run a given `IO` action over some `Foldable` concurrently. Thread usage is bounded to the number of CPUs available to the user.

Overall, internal usage of `throttled` introduces a very small slowdown relative to `mapConcurrently`, in exchange for much reduced CPU thrashing.