### PR TITLE
Replace shelly with `typed-process`

### DIFF
--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -22,76 +22,94 @@ import           Aura.Pacman (pacman)
 import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils
-import           BasePrelude hiding (FilePath)
+import           BasePrelude
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
 import           Control.Monad.Freer.Reader
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except
+import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Generics.Product (field)
 import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup.Foldable (fold1)
 import qualified Data.Set as S
 import           Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
+import qualified Data.Text as T
 import           Data.Witherable (wither)
-import           Filesystem.Path (filename)
 import           Lens.Micro ((^.))
-import           Shelly hiding (path)
+import           System.Directory (setCurrentDirectory)
 import           System.IO (hFlush, stdout)
+import           System.Path
+import           System.Path.IO
+import           System.Random.MWC (GenIO, uniform, createSystemRandom)
 
 ---
 
-srcPkgStore :: FilePath
-srcPkgStore = "/var/cache/aura/src"
+srcPkgStore :: Path Absolute
+srcPkgStore = fromAbsoluteFilePath "/var/cache/aura/src"
 
 -- | Expects files like: \/var\/cache\/pacman\/pkg\/*.pkg.tar.xz
 installPkgFiles :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
   NonEmptySet PackagePath -> Eff r ()
 installPkgFiles files = do
   ss <- ask
-  send . shelly @IO $ checkDBLock ss
-  rethrow . pacman $ ["-U"] <> map (toTextIgnore . path) (toList files) <> asFlag (commonConfigOf ss)
+  send $ checkDBLock ss
+  rethrow . pacman $ ["-U"] <> map (toFilePath . path) (toList files) <> asFlag (commonConfigOf ss)
 
 -- | All building occurs within temp directories,
 -- or in a location specified by the user with flags.
 buildPackages :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
   NonEmptySet Buildable -> Eff r (NonEmptySet PackagePath)
-buildPackages = wither build . toList >=> maybe bad (pure . fold1) . NEL.nonEmpty
+buildPackages bs = do
+  g <- send createSystemRandom
+  wither (build g) (toList bs) >>= maybe bad (pure . fold1) . NEL.nonEmpty
   where bad = throwError $ Failure buildFail_10
 
 -- | Handles the building of Packages. Fails nicely.
 -- Assumed: All dependencies are already installed.
 build :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
-  Buildable -> Eff r (Maybe (NonEmptySet PackagePath))
-build p = do
+  GenIO -> Buildable -> Eff r (Maybe (NonEmptySet PackagePath))
+build g p = do
   ss     <- ask
   send $ notify ss (buildPackages_1 (p ^. field @"name") (langOf ss)) *> hFlush stdout
-  result <- send . shelly @IO $ build' ss p
+  result <- send $ build' ss g p
   either (buildFail p) (pure . Just) result
 
--- | Should never throw a Shelly Exception. In theory all errors
+-- | Should never throw an IO Exception. In theory all errors
 -- will come back via the @Language -> String@ function.
-build' :: Settings -> Buildable -> Sh (Either Failure (NonEmptySet PackagePath))
-build' ss p = do
+build' :: Settings -> GenIO -> Buildable -> IO (Either Failure (NonEmptySet PackagePath))
+build' ss g b = do
   let pth = buildPathOf $ buildConfigOf ss
-  cd pth
-  withTmpDir $ \curr -> do
-    cd curr
-    runExceptT $ do
-      bs <- ExceptT $ getBuildScripts p usr
-      lift $ cd bs
-      lift $ overwritePkgbuild ss p
-      pNames <- ExceptT $ makepkg ss usr
-      paths  <- lift . fmap NES.fromNonEmpty . traverse (moveToCachePath ss) $ NES.toNonEmpty pNames
-      lift . when (S.member AllSource . makepkgFlagsOf $ buildConfigOf ss) $
-        makepkgSource usr >>= traverse_ moveToSourcePath
-      pure paths
+  createDirectoryIfMissing True pth
+  setCurrentDirectory $ toFilePath pth
+  buildDir <- randomDirName g b
+  createDirectoryIfMissing True buildDir
+  setCurrentDirectory $ toFilePath buildDir
+  runExceptT $ do
+    bs <- ExceptT $ cloneRepo b usr
+    lift . setCurrentDirectory $ toFilePath bs
+    lift $ overwritePkgbuild ss b
+    pNames <- ExceptT $ makepkg ss usr
+    paths  <- lift . fmap NES.fromNonEmpty . traverse (moveToCachePath ss) $ NES.toNonEmpty pNames
+    lift . when (S.member AllSource . makepkgFlagsOf $ buildConfigOf ss) $
+      makepkgSource usr >>= traverse_ moveToSourcePath
+    pure paths
+  -- TODO Remove temp dir unless user says not to
   where usr = fromMaybe (User "桜木花道") . buildUserOf $ buildConfigOf ss
 
-getBuildScripts :: Buildable -> User -> Sh (Either Failure FilePath)
-getBuildScripts pkg usr = do
-  currDir <- pwd
+-- | Create a temporary directory with a semi-random name based on
+-- the `Buildable` we're working with.
+randomDirName :: GenIO -> Buildable -> IO (Path Absolute)
+randomDirName g b = do
+  pwd <- getCurrentDirectory
+  v   <- uniform g :: IO Word
+  let dir = T.unpack (b ^. field @"name" . field @"name") <> "-" <> show v
+  pure $ pwd </> fromUnrootedFilePath dir
+
+cloneRepo :: Buildable -> User -> IO (Either Failure (Path Absolute))
+cloneRepo pkg usr = do
+  currDir <- getCurrentDirectory
   scriptsDir <- chown usr currDir [] *> clone pkg
   case scriptsDir of
     Nothing -> pure . Left . Failure . buildFail_7 $ pkg ^. field @"name"
@@ -99,9 +117,9 @@ getBuildScripts pkg usr = do
 
 -- | The user may have edited the original PKGBUILD. If they have, we need to
 -- overwrite what's been downloaded before calling `makepkg`.
-overwritePkgbuild :: Settings -> Buildable -> Sh ()
+overwritePkgbuild :: Settings -> Buildable -> IO ()
 overwritePkgbuild ss p = when (switch ss HotEdit || switch ss UseCustomizepkg) $
-  writefile "PKGBUILD" $ p ^. field @"pkgbuild" . field @"pkgbuild"
+  BL.writeFile "PKGBUILD" $ p ^. field @"pkgbuild" . field @"pkgbuild"
 
 -- | Inform the user that building failed. Ask them if they want to
 -- continue installing previous packages that built successfully.
@@ -115,12 +133,12 @@ buildFail p (Failure err) = do
   bool (throwError $ Failure buildFail_5) (pure Nothing) response
 
 -- | Moves a file to the pacman package cache and returns its location.
-moveToCachePath :: Settings -> FilePath -> Sh PackagePath
-moveToCachePath ss p = cp p newName $> PackagePath newName
-  where newName = pth </> filename p
+moveToCachePath :: Settings -> Path Absolute -> IO PackagePath
+moveToCachePath ss p = copyFile p newName $> PackagePath newName
+  where newName = pth </> takeFileName p
         pth     = either id id . cachePathOf $ commonConfigOf ss
 
 -- | Moves a file to the aura src package cache and returns its location.
-moveToSourcePath :: FilePath -> Sh FilePath
-moveToSourcePath p = mv p newName $> newName
-  where newName = srcPkgStore </> p
+moveToSourcePath :: Path Absolute -> IO (Path Absolute)
+moveToSourcePath p = renameFile p newName $> newName
+  where newName = srcPkgStore </> takeFileName p

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -83,7 +83,7 @@ upgrade pkgs fs = do
       if | null toUpgrade && null devel -> send . warn ss . upgradeAURPkgs_3 $ langOf ss
          | otherwise -> do
              reportPkgsToUpgrade toUpgrade (toList devel)
-             unless (switch ss DryRun) saveState
+             send . unless (switch ss DryRun) $ saveState ss
              traverse_ I.install . NES.fromSet $ S.fromList names <> pkgs <> devel
 
 possibleUpdates :: (Member (Reader Settings) r, Member IO r) => NonEmptySet SimplePkg -> Eff r [(AurInfo, Versioning)]
@@ -167,8 +167,7 @@ displayPkgbuild :: (Member (Reader Settings) r, Member IO r) => NonEmptySet PkgN
 displayPkgbuild ps = do
   man <- asks managerOf
   pbs <- catMaybes <$> traverse (send . getPkgbuild @IO man) (toList ps)
-  send . traverse_ T.putStrLn . intersperse border $ pbs ^.. each . field @"pkgbuild"
-  where border = "\n#========== NEXT PKGBUILD ==========#\n"
+  send . traverse_ (T.putStrLn . strictText) $ pbs ^.. each . field @"pkgbuild"
 
 isntMostRecent :: (AurInfo, Versioning) -> Bool
 isntMostRecent (ai, v) = trueVer > Just v

--- a/aura/lib/Aura/Diff.hs
+++ b/aura/lib/Aura/Diff.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- |
 -- Module    : Aura.Diff
 -- Copyright : (c) Colin Woodbury, 2012 - 2018
@@ -11,8 +9,9 @@
 module Aura.Diff where
 
 import Aura.Settings
-import BasePrelude hiding (FilePath)
-import Shelly
+import BasePrelude
+import System.Path (Path, Absolute, toFilePath)
+import System.Process.Typed (runProcess, proc)
 
 ---
 
@@ -20,6 +19,6 @@ import Shelly
 -- Output will be coloured unless colour is deactivated by
 -- `--color never` or by detection of a non-terminal output
 -- target.
-diff :: Settings -> FilePath -> FilePath -> Sh ()
-diff ss f1 f2 = errExit False . run_ "diff" $ c <> ["-u", toTextIgnore f1, toTextIgnore f2]
+diff :: MonadIO m => Settings -> Path Absolute -> Path Absolute -> m ()
+diff ss f1 f2 = void . runProcess . proc "diff" $ c <> ["-u", toFilePath f1, toFilePath f2]
   where c = bool ["--color"] [] $ shared ss (Colour Never)

--- a/aura/lib/Aura/Logo.hs
+++ b/aura/lib/Aura/Logo.hs
@@ -29,7 +29,7 @@ animateVersionMsg :: Settings -> T.Text -> [T.Text] -> IO ()
 animateVersionMsg ss auraVersion verMsg = do
   when (isTerminal ss) $ do
     hideCursor
-    traverse_ (T.putStrLn . padString verMsgPad) verMsg  -- Version message
+    traverse_ (T.putStrLn . padString (fromIntegral verMsgPad)) verMsg  -- Version message
     raiseCursorBy 7  -- Initial reraising of the cursor.
     drawPills 3
     traverse_ T.putStrLn $ renderPacmanHead ss 0 Open  -- Initial rendering of head.

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -17,55 +17,58 @@ module Aura.MakePkg
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (exitCode)
-import           BasePrelude hiding (FilePath)
+import           BasePrelude
 import           Control.Error.Util (note)
 import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
-import           Shelly hiding (cmd)
+import           System.Path (Path, Absolute, fromAbsoluteFilePath, (</>), toFilePath)
+import           System.Path.IO (getCurrentDirectory, getDirectoryContents)
+import           System.Process.Typed
 
 ---
 
 -- | The default location of the makepkg configuration: \/etc\/makepkg.conf
-makepkgConfFile :: FilePath
-makepkgConfFile = "/etc/makepkg.conf"
+makepkgConfFile :: Path Absolute
+makepkgConfFile = fromAbsoluteFilePath "/etc/makepkg.conf"
 
-makepkgCmd :: T.Text
-makepkgCmd = "/usr/bin/makepkg"
+makepkgCmd :: Path Absolute
+makepkgCmd = fromAbsoluteFilePath "/usr/bin/makepkg"
 
 -- | Given the current user name, build the package of whatever
 -- directory we're in.
-makepkg :: Settings -> User -> Sh (Either Failure (NonEmptySet FilePath))
-makepkg ss usr = fmap g . f $ make cmd (opts <> colour)
+makepkg :: Settings -> User -> IO (Either Failure (NonEmptySet (Path Absolute)))
+makepkg ss usr = fmap g . f . make $ proc cmd (opts <> colour)
   where (cmd, opts) = runStyle usr . foldMap asFlag . makepkgFlagsOf $ buildConfigOf ss
         f | switch ss DontSuppressMakepkg = id
-          | otherwise = print_stdout False . print_stderr False
+          -- TODO restore
+          | otherwise = id -- print_stdout False . print_stderr False
         g (ExitSuccess, fs) = note (Failure buildFail_9) . fmap NES.fromNonEmpty $ NEL.nonEmpty fs
         g _ = Left $ Failure buildFail_8
         colour | shared ss (Colour Never)  = ["--nocolor"]
                | shared ss (Colour Always) = []
                | isTerminal ss = []
-               | otherwise = ["--nocolor"]
+               | otherwise = ["--nocolor"] -- TODO is this right?
 
 -- | Actually build the package, guarding on exceptions.
 -- Yields the filepaths of the built package tarballs.
-make :: FilePath -> [T.Text] -> Sh (ExitCode, [FilePath])
-make cmd opts = errExit False $ do
-  run_ cmd opts
-  fs <- filter p <$> (pwd >>= ls)
-  ec <- exitCode <$> lastExitCode
+make :: ProcessConfig stdin stdout stderr -> IO (ExitCode, [Path Absolute])
+make pc = do
+  ec  <- runProcess pc
+  pwd <- getCurrentDirectory
+  fs  <- filter p . map (pwd </>) <$> getDirectoryContents pwd
   pure (ec, fs)
-  where p (toTextIgnore -> fp) = T.isSuffixOf "-x86_64.pkg.tar.xz" fp || T.isSuffixOf "-any.pkg.tar.xz" fp
+  where p (T.pack . toFilePath -> fp) = T.isSuffixOf "-x86_64.pkg.tar.xz" fp || T.isSuffixOf "-any.pkg.tar.xz" fp
 
 -- | Make a source package. See `man makepkg` and grep for `--allsource`.
-makepkgSource :: User -> Sh [FilePath]
+makepkgSource :: User -> IO [Path Absolute]
 makepkgSource usr = do
-  run_ cmd opts
-  filter (T.isSuffixOf ".src.tar.gz" . toTextIgnore) <$> (pwd >>= ls)
+  runProcess $ proc cmd opts
+  pwd <- getCurrentDirectory
+  filter (T.isSuffixOf ".src.tar.gz" . T.pack . toFilePath) . map (pwd </>) <$> getDirectoryContents pwd
     where (cmd, opts) = runStyle usr ["--allsource"]
 
 -- | As of makepkg v4.2, building with `--asroot` is no longer allowed.
-runStyle :: User -> [T.Text] -> (FilePath, [T.Text])
-runStyle (User usr) opts = ("sudo", ["-u", usr, makepkgCmd] <> opts)
+runStyle :: User -> [String] -> (FilePath, [String])
+runStyle (User usr) opts = ("sudo", ["-u", T.unpack usr, toFilePath makepkgCmd] <> opts)

--- a/aura/lib/Aura/Pkgbuild/Base.hs
+++ b/aura/lib/Aura/Pkgbuild/Base.hs
@@ -8,27 +8,29 @@
 
 module Aura.Pkgbuild.Base where
 
-import Aura.Pkgbuild.Editing
-import Aura.Settings
-import Aura.Types
-import BasePrelude hiding (FilePath)
-import Shelly
+import           Aura.Pkgbuild.Editing
+import           Aura.Settings
+import           Aura.Types
+import           BasePrelude
+import qualified Data.Text as T
+import           System.Path (Path, Absolute, FileExt(..), fromAbsoluteFilePath, fromUnrootedFilePath, (</>), (<.>))
 
 ---
 
 -- | The default location: \/var\/cache\/aura\/pkgbuilds\/
-pkgbuildCache :: FilePath
-pkgbuildCache = "/var/cache/aura/pkgbuilds/"
+pkgbuildCache :: Path Absolute
+pkgbuildCache = fromAbsoluteFilePath "/var/cache/aura/pkgbuilds/"
 
 -- | The expected path to a stored PKGBUILD, given some package name.
-pkgbuildPath :: PkgName -> FilePath
-pkgbuildPath (PkgName p) = pkgbuildCache </> p <.> "pb"
+pkgbuildPath :: PkgName -> Path Absolute
+pkgbuildPath (PkgName p) = pkgbuildCache </> fromUnrootedFilePath (T.unpack p) <.> FileExt "pb"
 
 -- One of my favourite functions in this code base.
 -- | Allow the user to customize a PKGBUILD, depending on if they specified
 -- @--hotedit@ and/or @--custom@.
-pbCustomization :: Settings -> Buildable -> Sh Buildable
-pbCustomization ss = foldl (>=>) pure [customizepkg ss, hotEdit ss]
+pbCustomization :: Settings -> Buildable -> IO Buildable
+pbCustomization = hotEdit
+-- pbCustomization ss = foldl (>=>) pure [customizepkg ss, hotEdit ss]
 
 -- | Package a Buildable, running the customization handler first.
 --
@@ -36,4 +38,4 @@ pbCustomization ss = foldl (>=>) pure [customizepkg ss, hotEdit ss]
 -- up user interaction, and there probably aren't enough packages in the list to
 -- make the concurrent scheduling worth it.
 packageBuildable :: Settings -> Buildable -> IO Package
-packageBuildable ss b = FromAUR <$> shelly (pbCustomization ss b)
+packageBuildable ss b = FromAUR <$> pbCustomization ss b

--- a/aura/lib/Aura/Pkgbuild/Fetch.hs
+++ b/aura/lib/Aura/Pkgbuild/Fetch.hs
@@ -22,9 +22,6 @@ import           Control.Exception (SomeException, catch)
 import           Control.Monad.Trans (MonadIO, liftIO)
 import           Data.Generics.Product (field)
 import qualified Data.Text as T
-import           Data.Text.Encoding.Error
-import qualified Data.Text.Lazy as TL
-import           Data.Text.Lazy.Encoding
 import           Lens.Micro ((^.))
 import           Network.HTTP.Client (Manager)
 import           Network.URI (escapeURIString, isUnescapedInURIComponent)
@@ -46,5 +43,5 @@ pkgbuildUrl p = baseUrl </> "cgit/aur.git/plain/PKGBUILD?h="
 getPkgbuild :: MonadIO m => Manager -> PkgName -> m (Maybe Pkgbuild)
 getPkgbuild m p = e $ do
   t <- urlContents m . pkgbuildUrl . T.unpack $ p ^. field @"name"
-  pure $ fmap (Pkgbuild . TL.toStrict . decodeUtf8With lenientDecode) t
+  pure $ fmap Pkgbuild t
   where e f = liftIO $ f `catch` (\(_ :: E) -> return Nothing)

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -16,24 +16,25 @@ module Aura.Pkgbuild.Records
 import           Aura.Pkgbuild.Base
 import           Aura.Types
 import           BasePrelude
+import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Generics.Product (field)
 import           Data.Set.NonEmpty (NonEmptySet)
-import qualified Data.Text as T
 import           Lens.Micro ((^.))
-import           Shelly (Sh, writefile, test_f, shelly, mkdir_p)
+import           System.Path (toFilePath)
+import           System.Path.IO (doesFileExist, createDirectoryIfMissing)
 
 ---
 
 -- | Does a given package has a PKGBUILD stored?
 -- This is `True` when a package has been built successfully once before.
 hasPkgbuildStored :: PkgName -> IO Bool
-hasPkgbuildStored = shelly . test_f . pkgbuildPath
+hasPkgbuildStored = doesFileExist . pkgbuildPath
 
 -- | Write the PKGBUILDs of some `Buildable`s to disk.
 storePkgbuilds :: NonEmptySet Buildable -> IO ()
-storePkgbuilds bs = shelly $ do
-  mkdir_p pkgbuildCache
-  traverse_ (\p -> writePkgbuild (p ^. field @"name") (p ^. field @"pkgbuild" . field @"pkgbuild")) bs
+storePkgbuilds bs = do
+  createDirectoryIfMissing True pkgbuildCache
+  traverse_ (\p -> writePkgbuild (p ^. field @"name") (p ^. field @"pkgbuild")) bs
 
-writePkgbuild :: PkgName -> T.Text -> Sh ()
-writePkgbuild pn pkgb = writefile (pkgbuildPath pn) pkgb
+writePkgbuild :: PkgName -> Pkgbuild -> IO ()
+writePkgbuild pn (Pkgbuild pb) = BL.writeFile (toFilePath $ pkgbuildPath pn) pb

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -16,6 +16,7 @@ module Aura.Pkgbuild.Security
 
 import           Aura.Languages
 import           Aura.Types (Pkgbuild(..), Language)
+import           Aura.Utils (strictText)
 import           BasePrelude hiding (Last, Word)
 import           Control.Error.Util (hush)
 import           Data.Generics.Product
@@ -48,7 +49,7 @@ blacklist = M.fromList $ downloading <> running <> permissions
 
 -- | Attempt to parse a PKGBUILD. Should succeed for all reasonable PKGBUILDs.
 parsedPB :: Pkgbuild -> Maybe List
-parsedPB (Pkgbuild pb) = hush . parse "PKGBUILD" $ T.unpack pb
+parsedPB (Pkgbuild pb) = hush . parse "PKGBUILD" . T.unpack $ strictText pb  -- TODO wasteful conversion!
 
 -- | Discover any banned terms lurking in a parsed PKGBUILD, paired with
 -- the surrounding context lines.

--- a/aura/package.yaml
+++ b/aura/package.yaml
@@ -43,11 +43,12 @@ dependencies:
   - http-client >= 0.5 && < 0.6
   - language-bash >= 0.7 && < 0.8
   - non-empty-containers >= 0.1 && < 0.2
+  - paths >= 0.2 && < 0.3
   - prettyprinter >= 1.2 && < 1.3
   - prettyprinter-ansi-terminal >= 1.1 && < 1.2
   - text >= 1.2 && < 1.3
   - transformers
-  - shelly >= 1.7 && < 1.9
+  - typed-process >= 0.2 && < 0.3
   - versions >= 3.4 && < 3.5
 
 library:
@@ -62,6 +63,7 @@ library:
     - aur >= 6.0.1 && < 7
     - bytestring
     - compactable >= 0.1 && < 0.2
+    - directory
     - filepath
     - generic-lens >= 1.0.0.1 && < 1.1
     - http-types >= 0.9 && < 0.13
@@ -69,10 +71,10 @@ library:
     - microlens >= 0.4 && < 0.5
     - microlens-ghc >= 0.4 && < 0.5
     - mtl >= 2.2 && < 2.3
+    - mwc-random >= 0.14 && < 0.15
     - network-uri >= 2.6 && < 2.7
     - semigroupoids >= 5.2 && < 5.4
     - stm
-    - system-filepath
     - time
     - witherable >= 0.2 && < 0.3
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,9 @@ packages:
 extra-deps:
   - algebraic-graphs-0.1.1.1
   - compactable-0.1.2.2
+  - mwc-random-0.14.0.0
   # - language-bash-0.7.1
+  - paths-0.2.0.0
   - git: https://github.com/knrafto/language-bash
     commit: a4d6262e49db62614744968939594df8c5bd6ae4
   - git: https://github.com/andrewthad/non-empty-containers


### PR DESCRIPTION
After producing a flamegraph of a heavy dep resolution task, I discovered that `Shelly` introduces a lot of unnecessary overhead. This PR removes shelly and adds other tweaks in attempt to make the flamegraph look nicer.