### PR TITLE
(aur) API calls should be honest about failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cabal.sandbox.config
 build/
 .stack-work/*
 **.cabal
+*.svg

--- a/aur/package.yaml
+++ b/aur/package.yaml
@@ -35,6 +35,7 @@ library:
   other-modules: []
   dependencies:
     - aeson >= 0.9 && < 1.4
+    - errors >= 2.3 && < 2.4
     - servant >= 0.9 && < 0.15
     - servant-client >= 0.13 && < 0.15
     - text

--- a/aur/package.yaml
+++ b/aur/package.yaml
@@ -1,5 +1,5 @@
 name:                aur
-version:             6.0.1
+version:             6.1.0
 synopsis:            Access metadata from the Arch Linux User Repository.
 description:         Access package information from Arch Linux\'s AUR via its
                      RPC interface. The main exposed functions reflect those of the RPC.

--- a/aur/tests/Test.hs
+++ b/aur/tests/Test.hs
@@ -18,10 +18,10 @@ suite m = testGroup "RPC Calls"
   ]
 
 infoTest :: Manager -> Assertion
-infoTest m = info m ["aura"] >>= assertBool "Good package" . not . null
+infoTest m = info m ["aura"] >>= \x -> (not . null <$> x) @?= Just True
 
 infoTest' :: Manager -> Assertion
-infoTest' m = info m ["aura1234567"] >>= assertBool "Bad package" . null
+infoTest' m = info m ["aura1234567"] >>= \x -> (null <$> x) @?= Just True
 
 searchTest :: Manager -> Assertion
 searchTest m = search m "aura" >>= assertBool "Good search" . not . null

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -90,7 +90,7 @@ executeOpts ops = do
     pPrintNoColor ops
     pPrintNoColor (buildConfigOf ss)
     pPrintNoColor (commonConfigOf ss)
-  let p (ps, ms) = rethrow . pacman $
+  let p (ps, ms) = liftEitherM . pacman $
         asFlag ps
         ++ foldMap asFlag ms
         ++ asFlag (commonConfigOf ss)

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -55,7 +55,7 @@ installPkgFiles :: (Member (Reader Settings) r, Member (Error Failure) r, Member
 installPkgFiles files = do
   ss <- ask
   send $ checkDBLock ss
-  rethrow . pacman $ ["-U"] <> map (toFilePath . path) (toList files) <> asFlag (commonConfigOf ss)
+  liftEitherM . pacman $ ["-U"] <> map (toFilePath . path) (toList files) <> asFlag (commonConfigOf ss)
 
 -- | All building occurs within temp directories,
 -- or in a location specified by the user with flags.

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -55,7 +55,7 @@ downgradePackages pkgs = do
   unless (null reals) $ do
     cache   <- send $ cacheContents cachePath
     choices <- traverse (getDowngradeChoice cache) $ toList reals
-    send (pacman $ "-U" : asFlag (commonConfigOf ss) <> map (toFilePath . path) choices) >>= liftEither
+    liftEitherM . pacman $ "-U" : asFlag (commonConfigOf ss) <> map (toFilePath . path) choices
 
 -- | For a given package, get a choice from the user about which version of it to
 -- downgrade to.
@@ -116,7 +116,7 @@ copyAndNotify dir (PackagePath p : ps) n = do
 -- a number provided by the user. The rest are deleted.
 cleanCache :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => Word -> Eff r ()
 cleanCache toSave
-  | toSave == 0 = ask >>= \ss -> send (warn ss . cleanCache_2 $ langOf ss) >> send (pacman ["-Scc"]) >>= liftEither
+  | toSave == 0 = ask >>= \ss -> send (warn ss . cleanCache_2 $ langOf ss) >> liftEitherM (pacman ["-Scc"])
   | otherwise   = do
       ss <- ask
       send . warn ss . cleanCache_3 toSave $ langOf ss

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -55,7 +55,7 @@ downgradePackages pkgs = do
   unless (null reals) $ do
     cache   <- send $ cacheContents cachePath
     choices <- traverse (getDowngradeChoice cache) $ toList reals
-    rethrow . pacman $ "-U" : asFlag (commonConfigOf ss) <> map (toFilePath . path) choices
+    send (pacman $ "-U" : asFlag (commonConfigOf ss) <> map (toFilePath . path) choices) >>= liftEither
 
 -- | For a given package, get a choice from the user about which version of it to
 -- downgrade to.
@@ -116,7 +116,7 @@ copyAndNotify dir (PackagePath p : ps) n = do
 -- a number provided by the user. The rest are deleted.
 cleanCache :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => Word -> Eff r ()
 cleanCache toSave
-  | toSave == 0 = ask >>= \ss -> send (warn ss . cleanCache_2 $ langOf ss) >> rethrow (pacman ["-Scc"])
+  | toSave == 0 = ask >>= \ss -> send (warn ss . cleanCache_2 $ langOf ss) >> send (pacman ["-Scc"]) >>= liftEither
   | otherwise   = do
       ss <- ask
       send . warn ss . cleanCache_3 toSave $ langOf ss

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -12,7 +12,7 @@
 
 module Aura.Commands.O ( displayOrphans, adoptPkg ) where
 
-import           Aura.Core (orphans, sudo, rethrow)
+import           Aura.Core (orphans, sudo, liftEither)
 import           Aura.Pacman (pacman)
 import           Aura.Settings (Settings)
 import           Aura.Types
@@ -33,4 +33,4 @@ displayOrphans = orphans >>= traverse_ (T.putStrLn . view (field @"name"))
 
 -- | Identical to @-D --asexplicit@.
 adoptPkg :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
-adoptPkg pkgs = sudo . rethrow . pacman $ ["-D", "--asexplicit"] <> asFlag pkgs
+adoptPkg pkgs = send (pacman $ ["-D", "--asexplicit"] <> asFlag pkgs) >>= sudo . liftEither

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -12,7 +12,7 @@
 
 module Aura.Commands.O ( displayOrphans, adoptPkg ) where
 
-import           Aura.Core (orphans, sudo, liftEither)
+import           Aura.Core (orphans, sudo, liftEitherM)
 import           Aura.Pacman (pacman)
 import           Aura.Settings (Settings)
 import           Aura.Types
@@ -33,4 +33,4 @@ displayOrphans = orphans >>= traverse_ (T.putStrLn . view (field @"name"))
 
 -- | Identical to @-D --asexplicit@.
 adoptPkg :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
-adoptPkg pkgs = send (pacman $ ["-D", "--asexplicit"] <> asFlag pkgs) >>= sudo . liftEither
+adoptPkg pkgs = sudo . liftEitherM . pacman $ ["-D", "--asexplicit"] <> asFlag pkgs

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -55,7 +55,7 @@ resolveDeps repo ps = do
   ss <- ask
   tv <- send $ newTVarIO M.empty
   ts <- send $ newTVarIO S.empty
-  send (resolveDeps' ss repo tv ts ps) >>= liftMaybe (Failure connectionFailure_1)
+  liftMaybeM (Failure connectionFailure_1) $ resolveDeps' ss repo tv ts ps
   m  <- send $ readTVarIO tv
   s  <- send $ readTVarIO ts
   unless (length ps == length m) $ send (putStr "\n")

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1095,6 +1095,12 @@ reportNotInLog_1 = \case
 -------------------------------
 -- Aura/AUR functions
 -------------------------------
+
+-- https://github.com/aurapm/aura/issues/498
+connectionFailure_1 :: Language -> Doc AnsiStyle
+connectionFailure_1 = \case
+  _ -> "Failed to contact the AUR. Do you have an internet connection?"
+
 infoFields :: Language -> [T.Text]
 infoFields = sequence [ Fields.repository
                       , Fields.name

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -124,12 +124,12 @@ sortAurInfo bs ai = sortBy compare' ai
 aurSearch :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => T.Text -> Eff r [AurInfo]
 aurSearch regex = do
   ss  <- ask
-  res <- send (search (managerOf ss) regex) >>= liftMaybe (Failure connectionFailure_1)
+  res <- liftMaybeM (Failure connectionFailure_1) $ search (managerOf ss) regex
   pure $ sortAurInfo (bool Nothing (Just SortAlphabetically) $ switch ss SortAlphabetically) res
 
 -- | Frontend to the `aur` library. For @-Ai@.
 aurInfo :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => NonEmpty PkgName -> Eff r [AurInfo]
 aurInfo pkgs = do
   m   <- asks managerOf
-  res <- send (info m . map (^. field @"name") $ toList pkgs) >>= liftMaybe (Failure connectionFailure_1)
+  res <- liftMaybeM (Failure connectionFailure_1) . info m . map (^. field @"name") $ toList pkgs
   pure $ sortAurInfo (Just SortAlphabetically) res

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -21,7 +21,7 @@ module Aura.State
 
 import           Aura.Cache
 import           Aura.Colour (red)
-import           Aura.Core (warn, notify, liftEither, report)
+import           Aura.Core (warn, notify, liftEitherM, report)
 import           Aura.Languages
 import           Aura.Pacman (pacmanOutput, pacman)
 import           Aura.Settings
@@ -160,5 +160,5 @@ reinstallAndRemove down remo
   | null remo = reinstall
   | null down = remove
   | otherwise = reinstall *> remove
-  where remove    = send (pacman $ "-R" : asFlag remo) >>= liftEither
-        reinstall = send (pacman $ "-U" : map (toFilePath . path) down) >>= liftEither
+  where remove    = liftEitherM . pacman $ "-R" : asFlag remo
+        reinstall = liftEitherM . pacman $ "-U" : map (toFilePath . path) down

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -21,7 +21,7 @@ module Aura.State
 
 import           Aura.Cache
 import           Aura.Colour (red)
-import           Aura.Core (warn, notify, rethrow, report)
+import           Aura.Core (warn, notify, liftEither, report)
 import           Aura.Languages
 import           Aura.Pacman (pacmanOutput, pacman)
 import           Aura.Settings
@@ -160,5 +160,5 @@ reinstallAndRemove down remo
   | null remo = reinstall
   | null down = remove
   | otherwise = reinstall *> remove
-  where remove    = rethrow . pacman $ "-R" : asFlag remo
-        reinstall = rethrow . pacman $ "-U" : map (toFilePath . path) down
+  where remove    = send (pacman $ "-R" : asFlag remo) >>= liftEither
+        reinstall = send (pacman $ "-U" : map (toFilePath . path) down) >>= liftEither

--- a/aura/package.yaml
+++ b/aura/package.yaml
@@ -80,7 +80,7 @@ library:
     - network-uri >= 2.6 && < 2.7
     - semigroupoids >= 5.2 && < 5.4
     - stm
-    - throttled >= 1.0 && < 1.1
+    - throttled >= 1.1 && < 1.2
     - time
     - witherable >= 0.2 && < 0.3
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,9 @@ extra-deps:
   - mwc-random-0.14.0.0
   # - language-bash-0.7.1
   - paths-0.2.0.0
-  - throttled-1.0.0
+  # - throttled-1.0.0
+  - git: https://gitlab.com/fosskers/throttled
+    commit: 753edca18f9d25450bc29cb14cf4481bafad9c52
   - git: https://github.com/knrafto/language-bash
     commit: a4d6262e49db62614744968939594df8c5bd6ae4
   - git: https://github.com/andrewthad/non-empty-containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.4
+resolver: lts-12.6
 
 packages:
   - aura/


### PR DESCRIPTION
### TODO

- [x] Update the `aur` API to include failure types
- [x] Update `aura` to use the altered functions

### Motivation

Currently, AUR RPC calls that fail (say, for lack of an internet connection) return `[]`. This is the same result as when a call succeeds but there was no package matching the lookup criteria. 

This PR makes the `aur` lib honest when hard failures occur. 

Fixes #498 