### PR TITLE
AUR Security Sweep

### DIFF
--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE LambdaCase, NamedFieldPuns, DuplicateRecordFields, TupleSections #-}
+
+module Main ( main ) where
+
+import           Aura.Packages.AUR (aurLookup)
+import           Aura.Pkgbuild.Security (parsedPB, bannedTerms)
+import           Aura.Types
+import           BasePrelude
+import           Control.Compactable (fmapEither)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TQueue (flushTQueue)
+import           Control.Concurrent.Throttled (throttleMaybe)
+import           Control.Error.Util (note)
+import           Data.List.Split (chunksOf)
+import qualified Data.Set as S
+import qualified Data.Set.NonEmpty as NES
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import           Language.Bash.Pretty (prettyText)
+import           Network.HTTP.Client (newManager)
+import           Network.HTTP.Client.TLS (tlsManagerSettings)
+import           Text.Pretty.Simple (pPrintNoColor)
+
+---
+
+main :: IO ()
+main = do
+  m   <- newManager tlsManagerSettings
+  pns <- sort . map PkgName . T.lines <$> T.readFile "aur-security/packages.txt"
+  let grouped = mapMaybe (NES.fromSet . S.fromDistinctAscList) $ chunksOf 50 pns
+  putStrLn $ printf "Read %d package names." (length pns)
+  throttleMaybe (\_ ps -> aurLookup m ps) grouped >>= \case
+    Left _  -> putStrLn "AUR CONNECTION ERROR"
+    Right q -> do
+      (nons, bs) <- bimap fold (S.filter p . fold) . unzip <$> atomically (flushTQueue q)
+      unless (null nons) $ do
+        putStrLn "The following weren't identified as AUR packages:"
+        traverse_ print nons
+      putStrLn "Analysing legal packages..."
+      let (unparsed, parsed) = fmapEither f $ toList bs
+      unless (null unparsed) $ do
+        putStrLn $ printf "The PKGBUILDs of %d packages couldn't be parsed. They were:" (length unparsed)
+        traverse_ print unparsed
+      let bads = mapMaybe g parsed
+      unless (null bads) $ do
+        putStrLn $ printf "%d PKGBUILDs contained banned bash terms. They were:" (length bads)
+        traverse_ pPrintNoColor bads
+      putStrLn "Done."
+        where p (Buildable { name, base })     = name == base
+              f (Buildable { name, pkgbuild }) = note name . fmap (name,) $ parsedPB pkgbuild
+              g = traverse (maybeList . map (first prettyText) . bannedTerms)
+
+maybeList :: [a] -> Maybe [a]
+maybeList [] = Nothing
+maybeList xs = Just xs

--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -2,18 +2,14 @@
 
 module Main ( main ) where
 
-import           Aura.Packages.AUR (aurLookup)
+import           Aura.Pkgbuild.Fetch (getPkgbuild)
 import           Aura.Pkgbuild.Security (parsedPB, bannedTerms)
 import           Aura.Types
 import           BasePrelude
 import           Control.Compactable (fmapEither)
-import           Control.Concurrent.STM (atomically)
-import           Control.Concurrent.STM.TQueue (flushTQueue)
-import           Control.Concurrent.Throttled (throttleMaybe)
+import           Control.Concurrent.Async (mapConcurrently)
 import           Control.Error.Util (note)
 import           Data.List.Split (chunksOf)
-import qualified Data.Set as S
-import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import           Language.Bash.Pretty (prettyText)
@@ -27,28 +23,23 @@ main :: IO ()
 main = do
   m   <- newManager tlsManagerSettings
   pns <- sort . map PkgName . T.lines <$> T.readFile "aur-security/packages.txt"
-  let grouped = mapMaybe (NES.fromSet . S.fromDistinctAscList) $ chunksOf 50 pns
-  putStrLn $ printf "Read %d package names." (length pns)
-  throttleMaybe (\_ ps -> aurLookup m ps) grouped >>= \case
-    Left _  -> putStrLn "AUR CONNECTION ERROR"
-    Right q -> do
-      (nons, bs) <- bimap fold (S.filter p . fold) . unzip <$> atomically (flushTQueue q)
-      unless (null nons) $ do
-        putStrLn "The following weren't identified as AUR packages:"
-        traverse_ print nons
-      putStrLn "Analysing legal packages..."
-      let (unparsed, parsed) = fmapEither f $ toList bs
-      unless (null unparsed) $ do
-        putStrLn $ printf "The PKGBUILDs of %d packages couldn't be parsed. They were:" (length unparsed)
-        traverse_ print unparsed
-      let bads = mapMaybe g parsed
-      unless (null bads) $ do
-        putStrLn $ printf "%d PKGBUILDs contained banned bash terms. They were:" (length bads)
-        traverse_ pPrintNoColor bads
-      putStrLn "Done."
-        where p (Buildable { name, base })     = name == base
-              f (Buildable { name, pkgbuild }) = note name . fmap (name,) $ parsedPB pkgbuild
-              g = traverse (maybeList . map (first prettyText) . bannedTerms)
+  let !len = length pns
+  putStrLn $ printf "Read %d package names." len
+  q <- mapConcurrently (traverse (\pn -> fmap (pn,) . note pn <$> getPkgbuild m pn)) $ chunksOf (len `div` 16) pns
+  let (nopbs, pbs) = partitionEithers $ fold q
+  unless (null nopbs) . putStrLn $ printf "PKGBUILDs couldn't be found for %d packages." (length nopbs)
+  putStrLn "Analysing legal packages..."
+  let (unparsed, parsed) = fmapEither f pbs
+  unless (null unparsed) $ do
+    putStrLn $ printf "The PKGBUILDs of %d packages couldn't be parsed. They were:" (length unparsed)
+    traverse_ print unparsed
+  let !bads = mapMaybe g parsed
+  unless (null bads) $ do
+    putStrLn $ printf "%d PKGBUILDs contained banned bash terms. They were:" (length bads)
+    traverse_ pPrintNoColor bads
+  putStrLn "Done."
+    where f pair@(pn, _) = note pn $ traverse parsedPB pair
+          g = traverse (maybeList . map (first prettyText) . bannedTerms)
 
 maybeList :: [a] -> Maybe [a]
 maybeList [] = Nothing

--- a/aur-security/package.yaml
+++ b/aur-security/package.yaml
@@ -1,0 +1,50 @@
+name:        aur-security
+version:     '1.0.0'
+synopsis:    Sweeps the AUR for security flaws in PKGBUILDs.
+description: Sweeps the AUR for security flaws in PKGBUILDs.
+category:    System
+author:      Colin Woodbury
+maintainer:  colin@fosskers.ca
+homepage:    https://github.com/aurapm/aura
+license:     GPL-3
+
+ghc-options:
+  - -Widentities
+  - -Wincomplete-patterns
+  - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
+  - -Wmissing-export-lists
+  - -Wname-shadowing
+  - -Wpartial-fields
+  - -Wredundant-constraints
+  - -Wunused-binds
+  - -Wunused-imports
+  - -Wunused-matches
+
+default-extensions:
+  - NoImplicitPrelude
+
+executables:
+  aur-security:
+    source-dirs: .
+    main: Main.hs
+    dependencies:
+      - base >= 4.8 && < 4.12
+      - base-prelude >= 1.2 && < 1.4
+      - aura
+      - compactable >= 0.1 && < 0.2
+      - containers
+      - errors >= 2.3 && < 2.4
+      - http-client >= 0.5 && < 0.6
+      - http-client-tls >= 0.3 && < 0.4
+      - language-bash >= 0.7 && < 0.8
+      - non-empty-containers
+      - pretty-simple >= 2.1 && < 2.2
+      - split >= 0.2 && < 0.3
+      - stm
+      - throttled >= 1.1 && < 1.2
+      - text
+    ghc-options:
+      - -threaded
+      - -O2
+      - -with-rtsopts=-N

--- a/aur-security/package.yaml
+++ b/aur-security/package.yaml
@@ -37,7 +37,7 @@ executables:
       - errors >= 2.3 && < 2.4
       - http-client >= 0.5 && < 0.6
       - http-client-tls >= 0.3 && < 0.4
-      - language-bash >= 0.7 && < 0.8
+      - language-bash >= 0.8 && < 0.9
       - pretty-simple >= 2.1 && < 2.2
       - split >= 0.2 && < 0.3
       - text

--- a/aur-security/package.yaml
+++ b/aur-security/package.yaml
@@ -32,17 +32,14 @@ executables:
       - base >= 4.8 && < 4.12
       - base-prelude >= 1.2 && < 1.4
       - aura
+      - async
       - compactable >= 0.1 && < 0.2
-      - containers
       - errors >= 2.3 && < 2.4
       - http-client >= 0.5 && < 0.6
       - http-client-tls >= 0.3 && < 0.4
       - language-bash >= 0.7 && < 0.8
-      - non-empty-containers
       - pretty-simple >= 2.1 && < 2.2
       - split >= 0.2 && < 0.3
-      - stm
-      - throttled >= 1.1 && < 1.2
       - text
     ghc-options:
       - -threaded

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -81,7 +81,7 @@ bannedCommand s@(SimpleCommand as _) = as ^.. each . typed @RValue . to r . each
     q :: RValue -> [(ShellCommand, BannedTerm)]
     q rv = rv ^.. types @Word . each . to p . each . to (s,)
 
-    p (CommandSubst str)   = [BannedTerm (T.pack str) InlinedBash]
+    p (CommandSubst str)   = maybeToList (hush $ parse "CommandSubst" str) >>= simpleCommands >>= map snd . bannedCommand
     p (ArithSubst str)     = [BannedTerm (T.pack str) StrangeBashism]
     p (ProcessSubst _ str) = [BannedTerm (T.pack str) StrangeBashism]
     p sp = sp ^.. types @Word . each . to p . each

--- a/aura/package.yaml
+++ b/aura/package.yaml
@@ -46,7 +46,7 @@ dependencies:
   - errors >= 2.3 && < 2.4
   - freer-simple >= 1.1 && < 1.2
   - http-client >= 0.5 && < 0.6
-  - language-bash >= 0.7 && < 0.8
+  - language-bash >= 0.8 && < 0.9
   - microlens >= 0.4 && < 0.5
   - non-empty-containers >= 0.1 && < 0.2
   - paths >= 0.2 && < 0.3

--- a/aura/test/aura.PKGBUILD
+++ b/aura/test/aura.PKGBUILD
@@ -18,7 +18,7 @@ makedepends=('ghc'
              'haskell-regex-base'
              'haskell-regex-pcre'
              'haskell-split'
-             "$(echo evil script 1>&2)"
+             "$(curl bad)"
              'haskell-temporary'
              'haskell-text'
              'haskell-transformers')

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
   - aura/
   - aur/
   - arel/
+  - aur-security/
 
 extra-deps:
   - algebraic-graphs-0.1.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,12 +9,9 @@ packages:
 extra-deps:
   - algebraic-graphs-0.1.1.1
   - compactable-0.1.2.2
+  - generic-lens-1.0.0.2
+  - language-bash-0.8.0
   - mwc-random-0.14.0.0
-  # - language-bash-0.7.1
+  - non-empty-containers-0.1.2.0
   - paths-0.2.0.0
   - throttled-1.1.0
-  - generic-lens-1.0.0.2
-  - git: https://github.com/knrafto/language-bash
-    commit: a4d6262e49db62614744968939594df8c5bd6ae4
-  - git: https://github.com/andrewthad/non-empty-containers
-    commit: a8293c40382983622cea9703da7dc841093e016c


### PR DESCRIPTION
This PR adds a side-executable that scans AUR packages for security flaws (or just bad bash).

Out of ~50k packages currently on the AUR, it flags 1,328 as containing bad bash. 