### PR TITLE
Smarter Concurrent Lookups

### DIFF
--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -51,7 +51,7 @@ common libexec
       errors >=2.3 && <2.4
     , freer-simple >=1.1 && <1.3
     , http-client >=0.5 && <0.6
-    , non-empty-containers >=0.1.2 && <0.2
+    , nonempty-containers ^>= 0.2
     , prettyprinter >=1.2 && <1.3
     , prettyprinter-ansi-terminal >=1.1 && <1.2
     , transformers >= 0.5

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -104,10 +104,11 @@ library
     , microlens-ghc ^>=0.4
     , mwc-random >=0.14 && <0.15
     , network-uri >=2.6 && <2.7
+    , scheduler ^>= 1.1
     , semigroupoids >=5.2 && <5.4
     , stm
-    , throttled >=1.1 && <1.2
     , time
+    , unliftio >= 0.2
     , witherable >=0.2 && <0.4
 
 executable aura

--- a/aura/exec/Settings.hs
+++ b/aura/exec/Settings.hs
@@ -51,7 +51,7 @@ getSettings (Program op co bc lng) = runExceptT $ do
   environment <- lift (M.fromList . map (bimap T.pack T.pack) <$> getEnvironment)
   manager     <- lift $ newManager tlsManagerSettings
   isTerm      <- lift $ hIsTerminalDevice stdout
-  fromGroups  <- lift . maybe (pure S.empty) groupPackages . NES.fromSet $ getIgnoredGroups confFile <> igg
+  fromGroups  <- lift . maybe (pure S.empty) groupPackages . NES.nonEmptySet $ getIgnoredGroups confFile <> igg
   let language = checkLang lng environment
   bu <- failWith (Failure whoIsBuildUser_1) $ buildUserOf bc <|> getTrueUser environment
   pure Settings { managerOf      = manager

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -134,7 +134,7 @@ executeOpts ops = do
     Right (Orphans o) ->
       case o of
         Nothing               -> send O.displayOrphans
-        Just OrphanAbandon    -> sudo $ send orphans >>= traverse_ removePkgs . NES.fromSet
+        Just OrphanAbandon    -> sudo $ send orphans >>= traverse_ removePkgs . NES.nonEmptySet
         Just (OrphanAdopt ps) -> O.adoptPkg ps
     Right Version   -> send $ getVersionInfo >>= animateVersionMsg ss auraVersion
     Right Languages -> displayOutputLanguages

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -46,6 +46,8 @@ import           Aura.Commands.O as O
 import           Aura.Core
 import           Aura.Languages
 import           Aura.Logo
+import           Aura.Packages.AUR (aurRepo)
+import           Aura.Packages.Repository (pacmanRepo)
 import           Aura.Pacman
 import           Aura.Settings
 import           Aura.Types
@@ -53,7 +55,7 @@ import           BasePrelude hiding (Version)
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
 import           Control.Monad.Freer.Reader
-import qualified Data.Set as S
+import           Data.Set (Set)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -69,26 +71,27 @@ import           Text.Pretty.Simple (pPrintNoColor)
 ---
 
 auraVersion :: T.Text
-auraVersion = "2.0.0"
+auraVersion = "2.0.1"
 
 main :: IO ()
 main = do
   options   <- execParser opts
   esettings <- getSettings options
+  repos     <- (<>) <$> pacmanRepo <*> aurRepo
   case esettings of
     Left err -> T.putStrLn . dtot . ($ English) $ failure err
-    Right ss -> execute ss options >>= exit ss
+    Right ss -> execute ss repos options >>= exit ss
 
-execute :: Settings -> Program -> IO (Either (Doc AnsiStyle) ())
-execute ss p = first (($ langOf ss) . failure) <$> (runM . runReader ss . runError . executeOpts $ _operation p)
+execute :: Settings -> Repository -> Program -> IO (Either (Doc AnsiStyle) ())
+execute ss r p = first (($ langOf ss) . failure) <$> (runM . runReader (Env r ss) . runError . executeOpts $ _operation p)
 
 exit :: Settings -> Either (Doc AnsiStyle) () -> IO a
 exit ss (Left e)  = scold ss e *> exitFailure
 exit _  (Right _) = exitSuccess
 
-executeOpts :: Either (PacmanOp, S.Set MiscOp) AuraOp -> Eff '[Error Failure, Reader Settings, IO] ()
+executeOpts :: Either (PacmanOp, Set MiscOp) AuraOp -> Eff '[Error Failure, Reader Env, IO] ()
 executeOpts ops = do
-  ss <- ask
+  ss <- asks settings
   when (shared ss Debug) $ do
     pPrintNoColor ops
     pPrintNoColor (buildConfigOf ss)
@@ -127,7 +130,7 @@ executeOpts ops = do
       case o of
         Nothing            -> L.viewLogFile
         Just (LogInfo ps)  -> L.logInfoOnPkg ps
-        Just (LogSearch s) -> ask >>= send . flip L.searchLogFile s
+        Just (LogSearch s) -> asks settings >>= send . flip L.searchLogFile s
     Right (Orphans o) ->
       case o of
         Nothing               -> send O.displayOrphans
@@ -137,13 +140,13 @@ executeOpts ops = do
     Right Languages -> displayOutputLanguages
     Right ViewConf  -> viewConfFile
 
-displayOutputLanguages :: (Member (Reader Settings) r, Member IO r) => Eff r ()
+displayOutputLanguages :: (Member (Reader Env) r, Member IO r) => Eff r ()
 displayOutputLanguages = do
-  ss <- ask
+  ss <- asks settings
   send . notify ss . displayOutputLanguages_1 $ langOf ss
   send $ traverse_ print [English ..]
 
-viewConfFile :: (Member (Reader Settings) r, Member IO r) => Eff r ()
+viewConfFile :: (Member (Reader Env) r, Member IO r) => Eff r ()
 viewConfFile = do
-  pth <- asks (either id id . configPathOf . commonConfigOf)
+  pth <- asks (either id id . configPathOf . commonConfigOf . settings)
   send . void . runProcess @IO $ proc "less" [toFilePath pth]

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -36,7 +36,7 @@ import           Data.Generics.Product (field)
 import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup.Foldable (fold1)
 import qualified Data.Set as S
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import           Data.Witherable (wither)
@@ -55,7 +55,7 @@ srcPkgStore = fromAbsoluteFilePath "/var/cache/aura/src"
 
 -- | Expects files like: \/var\/cache\/pacman\/pkg\/*.pkg.tar.xz
 installPkgFiles :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
-  NonEmptySet PackagePath -> Eff r ()
+  NESet PackagePath -> Eff r ()
 installPkgFiles files = do
   ss <- asks settings
   send $ checkDBLock ss
@@ -64,7 +64,7 @@ installPkgFiles files = do
 -- | All building occurs within temp directories,
 -- or in a location specified by the user with flags.
 buildPackages :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
-  NonEmptySet Buildable -> Eff r (NonEmptySet PackagePath)
+  NESet Buildable -> Eff r (NESet PackagePath)
 buildPackages bs = do
   g <- send createSystemRandom
   wither (build g) (toList bs) >>= maybe bad (pure . fold1) . NEL.nonEmpty
@@ -73,7 +73,7 @@ buildPackages bs = do
 -- | Handles the building of Packages. Fails nicely.
 -- Assumed: All dependencies are already installed.
 build :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
-  GenIO -> Buildable -> Eff r (Maybe (NonEmptySet PackagePath))
+  GenIO -> Buildable -> Eff r (Maybe (NESet PackagePath))
 build g p = do
   ss     <- asks settings
   send $ notify ss (buildPackages_1 (p ^. field @"name") (langOf ss)) *> hFlush stdout
@@ -82,7 +82,7 @@ build g p = do
 
 -- | Should never throw an IO Exception. In theory all errors
 -- will come back via the @Language -> String@ function.
-build' :: Settings -> GenIO -> Buildable -> IO (Either Failure (NonEmptySet PackagePath))
+build' :: Settings -> GenIO -> Buildable -> IO (Either Failure (NESet PackagePath))
 build' ss g b = do
   let pth = buildPathOf $ buildConfigOf ss
   createDirectoryIfMissing True pth
@@ -95,7 +95,7 @@ build' ss g b = do
     lift . setCurrentDirectory $ toFilePath bs
     lift $ overwritePkgbuild ss b
     pNames <- ExceptT $ makepkg ss usr
-    paths  <- lift . fmap NES.fromNonEmpty . traverse (moveToCachePath ss) $ NES.toNonEmpty pNames
+    paths  <- lift . fmap NES.fromList . traverse (moveToCachePath ss) $ NES.toList pNames
     lift . when (S.member AllSource . makepkgFlagsOf $ buildConfigOf ss) $
       makepkgSource usr >>= traverse_ moveToSourcePath
     pure paths

--- a/aura/lib/Aura/Cache.hs
+++ b/aura/lib/Aura/Cache.hs
@@ -27,12 +27,12 @@ import           BasePrelude
 import           Data.Generics.Product (field)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import           Lens.Micro ((^.))
-import           System.Path (Absolute, Path, fromAbsoluteFilePath, toFilePath,
-                              (</>))
+import           System.Path
+    (Absolute, Path, fromAbsoluteFilePath, toFilePath, (</>))
 import           System.Path.IO (getDirectoryContents)
 
 ---
@@ -57,7 +57,7 @@ cacheContents :: Path Absolute -> IO Cache
 cacheContents pth = cache . map (PackagePath . (pth </>)) <$> getDirectoryContents pth
 
 -- | All packages from a given `S.Set` who have a copy in the cache.
-pkgsInCache :: Settings -> NonEmptySet PkgName -> IO (S.Set PkgName)
+pkgsInCache :: Settings -> NESet PkgName -> IO (S.Set PkgName)
 pkgsInCache ss ps = do
   c <- cacheContents . either id id . cachePathOf $ commonConfigOf ss
   pure . S.filter (`NES.member` ps) . S.map (^. field @"name") . M.keysSet $ _cache c

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -39,7 +39,7 @@ import           Data.Generics.Product (field)
 import           Data.List.NonEmpty (nonEmpty)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import           Lens.Micro ((^?), _Just)
@@ -51,7 +51,7 @@ import           System.Path.IO (copyFile, doesDirectoryExist, removeFile)
 -- | Interactive. Gives the user a choice as to exactly what versions
 -- they want to downgrade to.
 downgradePackages :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
-  NonEmptySet PkgName -> Eff r ()
+  NESet PkgName -> Eff r ()
 downgradePackages pkgs = do
   ss    <- asks settings
   let cachePath = either id id . cachePathOf $ commonConfigOf ss

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -50,10 +50,10 @@ import           System.Path.IO (copyFile, doesDirectoryExist, removeFile)
 
 -- | Interactive. Gives the user a choice as to exactly what versions
 -- they want to downgrade to.
-downgradePackages :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
+downgradePackages :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
   NonEmptySet PkgName -> Eff r ()
 downgradePackages pkgs = do
-  ss    <- ask
+  ss    <- asks settings
   let cachePath = either id id . cachePathOf $ commonConfigOf ss
   reals <- send $ pkgsInCache ss pkgs
   traverse_ (report red reportBadDowngradePkgs_1) . nonEmpty . toList $ NES.toSet pkgs S.\\ reals
@@ -64,13 +64,13 @@ downgradePackages pkgs = do
 
 -- | For a given package, get a choice from the user about which version of it to
 -- downgrade to.
-getDowngradeChoice :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
+getDowngradeChoice :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
   Cache -> PkgName -> Eff r PackagePath
 getDowngradeChoice cache pkg =
   case nonEmpty $ getChoicesFromCache cache pkg of
     Nothing      -> throwError . Failure $ reportBadDowngradePkgs_2 pkg
     Just choices -> do
-      ss <- ask
+      ss <- asks settings
       send . notify ss . getDowngradeChoice_1 pkg $ langOf ss
       send $ getSelection (T.pack . toFilePath . path) choices
 
@@ -78,40 +78,40 @@ getChoicesFromCache :: Cache -> PkgName -> [PackagePath]
 getChoicesFromCache (Cache cache) p = sort . M.elems $ M.filterWithKey (\(SimplePkg pn _) _ -> p == pn) cache
 
 -- | Print all package filenames that match a given `T.Text`.
-searchCache :: (Member (Reader Settings) r, Member IO r) => T.Text -> Eff r ()
+searchCache :: (Member (Reader Env) r, Member IO r) => T.Text -> Eff r ()
 searchCache ps = do
-  ss <- ask
+  ss <- asks settings
   matches <- send $ cacheMatches ss ps
   send . traverse_ (putStrLn . toFilePath . path) $ sort matches
 
 -- | The destination folder must already exist for the back-up to begin.
-backupCache :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => Path Absolute -> Eff r ()
+backupCache :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => Path Absolute -> Eff r ()
 backupCache dir = do
   exists <- send $ doesDirectoryExist dir
   if | not exists -> throwError $ Failure backupCache_3
      | otherwise  -> confirmBackup dir >>= backup dir
 
-confirmBackup :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => Path Absolute -> Eff r Cache
+confirmBackup :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => Path Absolute -> Eff r Cache
 confirmBackup dir = do
-  ss    <- ask
+  ss    <- asks settings
   cache <- send . cacheContents . either id id . cachePathOf $ commonConfigOf ss
   send . notify ss $ backupCache_4 (toFilePath dir) (langOf ss)
   send . notify ss $ backupCache_5 (M.size $ _cache cache) (langOf ss)
   okay  <- send $ optionalPrompt ss backupCache_6
   bool (throwError $ Failure backupCache_7) (pure cache) okay
 
-backup :: (Member (Reader Settings) r, Member IO r) => Path Absolute -> Cache -> Eff r ()
+backup :: (Member (Reader Env) r, Member IO r) => Path Absolute -> Cache -> Eff r ()
 backup dir (Cache cache) = do
-  ss <- ask
+  ss <- asks settings
   send . notify ss . backupCache_8 $ langOf ss
   send $ putStrLn ""  -- So that the cursor can rise at first.
   copyAndNotify dir (M.elems cache) 1
 
 -- | Manages the file copying and display of the real-time progress notifier.
-copyAndNotify :: (Member (Reader Settings) r, Member IO r) => Path Absolute -> [PackagePath] -> Int -> Eff r ()
+copyAndNotify :: (Member (Reader Env) r, Member IO r) => Path Absolute -> [PackagePath] -> Int -> Eff r ()
 copyAndNotify _ [] _ = pure ()
 copyAndNotify dir (PackagePath p : ps) n = do
-  ss <- ask
+  ss <- asks settings
   send $ raiseCursorBy 1
   send . warn ss . copyAndNotify_1 n $ langOf ss
   send $ copyFile p dir
@@ -119,18 +119,19 @@ copyAndNotify dir (PackagePath p : ps) n = do
 
 -- | Keeps a certain number of package files in the cache according to
 -- a number provided by the user. The rest are deleted.
-cleanCache :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => Word -> Eff r ()
+cleanCache :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => Word -> Eff r ()
 cleanCache toSave
-  | toSave == 0 = ask >>= \ss -> send (warn ss . cleanCache_2 $ langOf ss) >> liftEitherM (pacman ["-Scc"])
+  | toSave == 0 = asks settings >>= \ss ->
+      send (warn ss . cleanCache_2 $ langOf ss) >> liftEitherM (pacman ["-Scc"])
   | otherwise   = do
-      ss <- ask
+      ss <- asks settings
       send . warn ss . cleanCache_3 toSave $ langOf ss
       okay <- send $ optionalPrompt ss cleanCache_4
       bool (throwError $ Failure cleanCache_5) (clean (fromIntegral toSave)) okay
 
-clean :: (Member (Reader Settings) r, Member IO r) => Int -> Eff r ()
+clean :: (Member (Reader Env) r, Member IO r) => Int -> Eff r ()
 clean toSave = do
-  ss <- ask
+  ss <- asks settings
   send . notify ss . cleanCache_6 $ langOf ss
   let cachePath = either id id . cachePathOf $ commonConfigOf ss
   (Cache cache) <- send $ cacheContents cachePath
@@ -141,9 +142,9 @@ clean toSave = do
 
 -- | Only package files with a version not in any PkgState will be
 -- removed.
-cleanNotSaved :: (Member (Reader Settings) r, Member IO r) => Eff r ()
+cleanNotSaved :: (Member (Reader Env) r, Member IO r) => Eff r ()
 cleanNotSaved = do
-  ss <- ask
+  ss <- asks settings
   send . notify ss . cleanNotSaved_1 $ langOf ss
   sfs <- send getStateFiles
   states <- fmap catMaybes . send $ traverse readState sfs

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Freer.Reader
 import qualified Data.ByteString.Char8 as BS
 import           Data.Generics.Product (field)
 import qualified Data.List.NonEmpty as NEL
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Text as T
 import           Data.Text.Encoding as T
 import           Data.Text.Encoding.Error (lenientDecode)
@@ -66,7 +66,7 @@ searchLogFile ss input = do
   traverse_ T.putStrLn $ searchLines input logFile
 
 -- | The result of @-Li@.
-logInfoOnPkg :: (Member (Reader Env) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
+logInfoOnPkg :: (Member (Reader Env) r, Member IO r) => NESet PkgName -> Eff r ()
 logInfoOnPkg pkgs = do
   ss <- asks settings
   let pth = toFilePath . either id id . logPathOf $ commonConfigOf ss

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -22,7 +22,7 @@ import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
 import           Control.Monad.Freer.Reader
 import           Data.Generics.Product (field)
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Text.IO as T
 import           Lens.Micro.Extras (view)
 
@@ -33,5 +33,5 @@ displayOrphans :: IO ()
 displayOrphans = orphans >>= traverse_ (T.putStrLn . view (field @"name"))
 
 -- | Identical to @-D --asexplicit@.
-adoptPkg :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
+adoptPkg :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => NESet PkgName -> Eff r ()
 adoptPkg pkgs = sudo . liftEitherM . pacman $ ["-D", "--asexplicit"] <> asFlag pkgs

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -14,9 +14,8 @@
 
 module Aura.Commands.O ( displayOrphans, adoptPkg ) where
 
-import           Aura.Core (liftEitherM, orphans, sudo)
+import           Aura.Core (Env(..), liftEitherM, orphans, sudo)
 import           Aura.Pacman (pacman)
-import           Aura.Settings (Settings)
 import           Aura.Types
 import           BasePrelude
 import           Control.Monad.Freer
@@ -34,5 +33,5 @@ displayOrphans :: IO ()
 displayOrphans = orphans >>= traverse_ (T.putStrLn . view (field @"name"))
 
 -- | Identical to @-D --asexplicit@.
-adoptPkg :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
+adoptPkg :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) => NonEmptySet PkgName -> Eff r ()
 adoptPkg pkgs = sudo . liftEitherM . pacman $ ["-D", "--asexplicit"] <> asFlag pkgs

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE MonoLocalBinds   #-}
 {-# LANGUAGE MultiWayIf       #-}
 {-# LANGUAGE RankNTypes       #-}
@@ -25,18 +26,17 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
 import           BasePrelude
-import           Control.Concurrent.STM.TQueue
 import           Control.Concurrent.STM.TVar
-import           Control.Concurrent.Throttled (throttleMaybe_)
-import           Control.Error.Util (hush, note)
+import           Control.Error.Util (note)
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
 import           Control.Monad.Freer.Reader
-import           Control.Monad.Trans.Class (lift)
-import           Control.Monad.Trans.Maybe
+import           Control.Scheduler hiding (traverse_)
 import           Data.Generics.Product (field)
 import qualified Data.List.NonEmpty as NEL
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
@@ -45,6 +45,7 @@ import           Data.Versions
 import           Data.Witherable (wither)
 import           Lens.Micro
 import           System.IO (hFlush, stdout)
+import           UnliftIO.Exception (catchAny, throwString)
 
 ---
 
@@ -63,7 +64,8 @@ resolveDeps repo ps = do
   ss <- ask
   tv <- send $ newTVarIO M.empty
   ts <- send $ newTVarIO S.empty
-  liftMaybeM (Failure connectionFailure_1) $ resolveDeps' ss repo tv ts ps
+  liftMaybeM (Failure connectionFailure_1) $
+    (Just <$> resolveDeps' ss repo tv ts ps) `catchAny` (const $ pure Nothing)
   m  <- send $ readTVarIO tv
   s  <- send $ readTVarIO ts
   unless (length ps == length m) $ send (putStr "\n")
@@ -71,14 +73,27 @@ resolveDeps repo ps = do
   unless (null de) . throwError . Failure $ missingPkg_2 de
   either throwError pure $ sortInstall m
 
--- | An empty list signals success.
-resolveDeps' :: Settings -> Repository -> TVar (M.Map PkgName Package) -> TVar (S.Set PkgName) -> NonEmptySet Package -> IO (Maybe ())
-resolveDeps' ss repo tv ts ps = hush <$> throttleMaybe_ h ps
+resolveDeps'
+  :: Settings
+  -> Repository
+  -> TVar (Map PkgName Package)
+  -- ^ A cache of `Package`s that have already
+  -- been checked by the `j` function below.
+  -> TVar (Set PkgName)
+  -- ^ A cache of packages which have already been
+  -- confirmed to be installed, or otherwise "satisfied".
+  -> NonEmptySet Package
+  -- ^ The set of `Package`s to solve deps for.
+  -> IO ()
+resolveDeps' ss repo tv ts ps =
+  withScheduler_ Par' $ \sch -> traverse_ (scheduleWork sch . h sch) ps
   where
     -- | Handles determining whether further work should be done. It won't
     -- continue to `j` if this `Package` has already been analysed.
-    h :: TQueue Package -> Package -> IO (Maybe ())
-    h tq p = do
+    h :: Scheduler IO () -> Package -> IO ()
+    h sch p = do
+      -- We do the existance check and the `M.insert` in the same transaction to
+      -- guarantee that no package will be fully checked more than once.
       w <- atomically $ do
         let pn = pname p
         m <- readTVar tv
@@ -86,31 +101,39 @@ resolveDeps' ss repo tv ts ps = hush <$> throttleMaybe_ h ps
           Just _  -> pure WroteNothing
           Nothing -> modifyTVar' tv (M.insert pn p) $> WroteNew
       case w of
-        WroteNothing -> pure $ Just ()
+        WroteNothing -> pure ()
         WroteNew     -> case p of
-          FromRepo _ -> pure $ Just ()
-          FromAUR b  -> readTVarIO tv >>= j tq b
+          -- Pacman will solve further deps for "repo" packages by itself.
+          FromRepo _ -> pure ()
+          -- We check for conflicts / recursive deps for AUR packages manually.
+          FromAUR b  -> readTVarIO tv >>= j sch b
 
-    -- | Check for the existance of dependencies, as well as for any version conflicts
-    -- they might introduce.
-    j :: TQueue Package -> Buildable -> M.Map PkgName Package -> IO (Maybe ())
-    j tq b m = do
+    -- | Check for the existance of dependencies, as well as for any version
+    -- conflicts that they might introduce.
+    j :: Scheduler IO () -> Buildable -> Map PkgName Package -> IO ()
+    j sch b m = do
       s <- readTVarIO ts
       (ds, sd) <- fmap partitionEithers . wither (satisfied m s) $ b ^. field @"deps"
       atomically $ modifyTVar' ts (<> S.fromList sd)
-      case NEL.nonEmpty $ ds ^.. each . field @"name" of
-        Nothing -> pure $ Just ()
-        Just deps' -> do
-          putStr "." *> hFlush stdout
-          runMaybeT $ MaybeT (repoLookup repo ss $ NES.fromNonEmpty deps') >>= \(_, goods) ->
-            unless (null goods) (lift . atomically $ traverse_ (writeTQueue tq) goods)
+      forM_ (NEL.nonEmpty $ ds ^.. each . field @"name") $ \deps' -> do
+        putStr "." *> hFlush stdout
+        repoLookup repo ss (NES.fromNonEmpty deps') >>= \case
+          Nothing -> throwString "Connection Error"
+          Just (_, goods) -> traverse_ (scheduleWork sch . h sch) goods
 
-    satisfied :: M.Map PkgName Package -> S.Set PkgName -> Dep -> IO (Maybe (Either Dep PkgName))
-    satisfied m s d | M.member dn m || S.member dn s = pure Nothing
-                    | otherwise = Just . bool (Left d) (Right dn) <$> isSatisfied d
-      where dn = d ^. field @"name"
+    satisfied :: Map PkgName Package -> Set PkgName -> Dep -> IO (Maybe (Either Dep PkgName))
+    satisfied m s d
+      -- This `Dep` has already been checked.
+      | M.member dn m || S.member dn s = pure Nothing
+      -- Check if a `Dep` is installed, or is otherwise "satisfied" by some
+      -- installed package. This invokes a shell call to Pacman, hence the
+      -- desire to cache the result.
+      | otherwise = Just . bool (Left d) (Right dn) <$> isSatisfied d
+      where
+        dn :: PkgName
+        dn = d ^. field @"name"
 
-conflicts :: Settings -> M.Map PkgName Package -> S.Set PkgName -> [DepError]
+conflicts :: Settings -> Map PkgName Package -> Set PkgName -> [DepError]
 conflicts ss m s = foldMap f m
   where pm = M.fromList $ foldr (\p acc -> (pprov p ^. field @"provides" . to PkgName, p) : acc) [] m
         f (FromRepo _) = []
@@ -121,7 +144,7 @@ conflicts ss m s = foldMap f m
                                     Nothing -> Just $ NonExistant dn
                                     Just p  -> realPkgConflicts ss (b ^. field @"name") p d
 
-sortInstall :: M.Map PkgName Package -> Either Failure (NonEmpty (NonEmptySet Package))
+sortInstall :: Map PkgName Package -> Either Failure (NonEmpty (NonEmptySet Package))
 sortInstall m = case cycles depGraph of
   [] -> note (Failure missingPkg_3) . NEL.nonEmpty . mapMaybe NES.fromSet $ batch depGraph
   cs -> Left . Failure . missingPkg_4 $ map (NEL.map pname . NAM.vertexList1) cs
@@ -137,12 +160,12 @@ cycles = filter (not . isAcyclic) . vertexList . scc
 
 -- | Find the vertices that have no dependencies.
 -- O(n) complexity.
-leaves :: Ord a => AdjacencyMap a -> S.Set a
+leaves :: Ord a => AdjacencyMap a -> Set a
 leaves x = S.filter (null . flip postSet x) $ vertexSet x
 
 -- | Split a graph into batches of mutually independent vertices.
 -- Probably O(m * n * log(n)) complexity.
-batch :: Ord a => AdjacencyMap a -> [S.Set a]
+batch :: Ord a => AdjacencyMap a -> [Set a]
 batch g | isEmpty g = []
         | otherwise = ls : batch (induce (`S.notMember` ls) g)
   where ls = leaves g

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -58,10 +58,10 @@ data Wrote = WroteNothing | WroteNew
 -- interdependent, and thus can be built and installed as a group.
 --
 -- Deeper layers of the result list (generally) depend on the previous layers.
-resolveDeps :: (Member (Reader Settings) r, Member (Error Failure) r, Member IO r) =>
+resolveDeps :: (Member (Reader Env) r, Member (Error Failure) r, Member IO r) =>
   Repository -> NonEmptySet Package -> Eff r (NonEmpty (NonEmptySet Package))
 resolveDeps repo ps = do
-  ss <- ask
+  ss <- asks settings
   tv <- send $ newTVarIO M.empty
   ts <- send $ newTVarIO S.empty
   liftMaybeM (Failure connectionFailure_1) $

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -23,12 +23,12 @@ import           BasePrelude
 import           Control.Error.Util (note)
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.List.NonEmpty as NEL
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import           Lens.Micro ((^.), _2)
-import           System.Path (Absolute, Path, fromAbsoluteFilePath, toFilePath,
-                              (</>))
+import           System.Path
+    (Absolute, Path, fromAbsoluteFilePath, toFilePath, (</>))
 import           System.Path.IO (getCurrentDirectory, getDirectoryContents)
 import           System.Process.Typed
 
@@ -43,10 +43,10 @@ makepkgCmd = fromAbsoluteFilePath "/usr/bin/makepkg"
 
 -- | Given the current user name, build the package of whatever
 -- directory we're in.
-makepkg :: Settings -> User -> IO (Either Failure (NonEmptySet (Path Absolute)))
+makepkg :: Settings -> User -> IO (Either Failure (NESet (Path Absolute)))
 makepkg ss usr = make ss usr (proc cmd $ opts <> colour) >>= g
   where (cmd, opts) = runStyle usr . foldMap asFlag . makepkgFlagsOf $ buildConfigOf ss
-        g (ExitSuccess, _, fs)   = pure . note (Failure buildFail_9) . fmap NES.fromNonEmpty $ NEL.nonEmpty fs
+        g (ExitSuccess, _, fs)   = pure . note (Failure buildFail_9) . fmap NES.fromList $ NEL.nonEmpty fs
         g (ExitFailure _, se, _) = do
           unless (switch ss DontSuppressMakepkg) $ do
             showError <- optionalPrompt ss buildFail_11

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -42,7 +42,7 @@ import           Control.Monad.Trans.Maybe
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)
 import qualified Data.Set as S
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import           Data.Versions (versioning)
@@ -57,7 +57,7 @@ import           System.Process.Typed
 ---
 
 -- | Attempt to retrieve info about a given `S.Set` of packages from the AUR.
-aurLookup :: Manager -> NonEmptySet PkgName -> IO (Maybe (S.Set PkgName, S.Set Buildable))
+aurLookup :: Manager -> NESet PkgName -> IO (Maybe (S.Set PkgName, S.Set Buildable))
 aurLookup m names = runMaybeT $ MaybeT (info m (foldMap (\(PkgName pn) -> [pn]) names)) >>= \infos -> do
   badsgoods <- lift $ traverseConcurrently Par' (buildable m) infos
   let (bads, goods) = partitionEithers badsgoods

--- a/aura/lib/Aura/Pacman.hs
+++ b/aura/lib/Aura/Pacman.hs
@@ -40,7 +40,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import qualified Data.Text as T
 import           Data.Text.Encoding (decodeUtf8With)
 import           Data.Text.Encoding.Error (lenientDecode)
@@ -106,7 +106,7 @@ getIgnoredGroups :: Config -> S.Set PkgGroup
 getIgnoredGroups (Config c) = maybe S.empty (S.fromList . map PkgGroup) $ M.lookup "IgnoreGroup" c
 
 -- | Given a `Set` of package groups, yield all the packages they contain.
-groupPackages :: NonEmptySet PkgGroup -> IO (S.Set PkgName)
+groupPackages :: NESet PkgGroup -> IO (S.Set PkgName)
 groupPackages igs | null igs  = pure S.empty
                   | otherwise = fmap f . pacmanOutput $ "-Qg" : asFlag igs
   where f = S.fromList . map (PkgName . strictText . (!! 1) . BL.words) . BL.lines

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -19,7 +19,7 @@ import           Aura.Types
 import           BasePrelude
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Generics.Product (field)
-import           Data.Set.NonEmpty (NonEmptySet)
+import           Data.Set.NonEmpty (NESet)
 import           Lens.Micro ((^.))
 import           System.Path (toFilePath)
 import           System.Path.IO (createDirectoryIfMissing, doesFileExist)
@@ -32,7 +32,7 @@ hasPkgbuildStored :: PkgName -> IO Bool
 hasPkgbuildStored = doesFileExist . pkgbuildPath
 
 -- | Write the PKGBUILDs of some `Buildable`s to disk.
-storePkgbuilds :: NonEmptySet Buildable -> IO ()
+storePkgbuilds :: NESet Buildable -> IO ()
 storePkgbuilds bs = do
   createDirectoryIfMissing True pkgbuildCache
   traverse_ (\p -> writePkgbuild (p ^. field @"name") (p ^. field @"pkgbuild")) bs

--- a/aura/lib/Aura/Settings.hs
+++ b/aura/lib/Aura/Settings.hs
@@ -46,10 +46,11 @@ instance Flagable Makepkg where
 -- | Flags that are common to both Aura and Pacman.
 -- Aura will react to them, but also pass them through to `pacman`
 -- calls if necessary.
-data CommonConfig = CommonConfig { cachePathOf      :: !(Either (Path Absolute) (Path Absolute))
-                                 , configPathOf     :: !(Either (Path Absolute) (Path Absolute))
-                                 , logPathOf        :: !(Either (Path Absolute) (Path Absolute))
-                                 , commonSwitchesOf :: !(S.Set CommonSwitch) } deriving (Show, Generic)
+data CommonConfig = CommonConfig
+  { cachePathOf      :: !(Either (Path Absolute) (Path Absolute))
+  , configPathOf     :: !(Either (Path Absolute) (Path Absolute))
+  , logPathOf        :: !(Either (Path Absolute) (Path Absolute))
+  , commonSwitchesOf :: !(S.Set CommonSwitch) } deriving (Show, Generic)
 
 instance Flagable CommonConfig where
   asFlag (CommonConfig cap cop lfp cs) =
@@ -78,11 +79,12 @@ instance Flagable ColourMode where
   asFlag Auto   = ["auto"]
 
 -- | Settings unique to the AUR package building process.
-data BuildConfig = BuildConfig { makepkgFlagsOf  :: !(S.Set Makepkg)
-                               , buildPathOf     :: !(Path Absolute)
-                               , buildUserOf     :: !(Maybe User)
-                               , truncationOf    :: !Truncation  -- For `-As`
-                               , buildSwitchesOf :: !(S.Set BuildSwitch) } deriving (Show)
+data BuildConfig = BuildConfig
+  { makepkgFlagsOf  :: !(S.Set Makepkg)
+  , buildPathOf     :: !(Path Absolute)
+  , buildUserOf     :: !(Maybe User)
+  , truncationOf    :: !Truncation  -- For `-As`
+  , buildSwitchesOf :: !(S.Set BuildSwitch) } deriving (Show)
 
 -- | Extra options for customizing the build process.
 data BuildSwitch = DeleteMakeDeps
@@ -107,14 +109,15 @@ shared :: Settings -> CommonSwitch -> Bool
 shared ss c = S.member c . commonSwitchesOf $ commonConfigOf ss
 
 -- | The global settings as set by the user with command-line flags.
-data Settings = Settings { managerOf      :: !Manager
-                         , envOf          :: !Environment
-                         , langOf         :: !Language
-                         , editorOf       :: !FilePath
-                         , isTerminal     :: !Bool
-                         , ignoresOf      :: !(S.Set PkgName)
-                         , commonConfigOf :: !CommonConfig
-                         , buildConfigOf  :: !BuildConfig }
+data Settings = Settings
+  { managerOf      :: !Manager
+  , envOf          :: !Environment
+  , langOf         :: !Language
+  , editorOf       :: !FilePath
+  , isTerminal     :: !Bool
+  , ignoresOf      :: !(S.Set PkgName)
+  , commonConfigOf :: !CommonConfig
+  , buildConfigOf  :: !BuildConfig }
 
 -- | Unless otherwise specified, packages will be built within @/tmp@.
 defaultBuildDir :: Path Absolute

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,4 +11,4 @@ extra-deps:
   - language-bash-0.8.0
   - non-empty-containers-0.1.4.0
   - paths-0.2.0.0
-  - throttled-1.1.0
+  - scheduler-1.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.20
+resolver: lts-13.21
 
 packages:
   - aura/

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,6 @@ packages:
 extra-deps:
   - compactable-0.1.2.3
   - language-bash-0.8.0
-  - non-empty-containers-0.1.4.0
+  - nonempty-containers-0.2.0.0
   - paths-0.2.0.0
   - scheduler-1.1.0


### PR DESCRIPTION
This PR introduces usage of the `scheduler` library to make concurrent package lookups much cleaner.