### PR TITLE
Fix parsing output of pacman

### DIFF
--- a/aura/lib/Aura/Pacman.hs
+++ b/aura/lib/Aura/Pacman.hs
@@ -36,7 +36,7 @@ module Aura.Pacman
 import           Aura.Languages
 import           Aura.Types
 import           Aura.Utils (strictText)
-import           BasePrelude hiding (some, try)
+import           BasePrelude hiding (setEnv, some, try)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.Map.Strict as M
@@ -127,19 +127,24 @@ getLogFilePath (Config c) = c ^? at "LogFile" . _Just . _head . to (fromAbsolute
 ----------
 -- ACTIONS
 ----------
+
+-- | Create a pacman process to run.
+pacmanProc :: [String] -> ProcessConfig () () ()
+pacmanProc args = setEnv [("LC_ALL", "C")] $ proc "pacman" args
+
 -- | Run a pacman action that may fail. Will never throw an IO exception.
 pacman :: [T.Text] -> IO (Either Failure ())
 pacman (map T.unpack -> args) = do
-  ec <- runProcess $ proc "pacman" args
+  ec <- runProcess $ pacmanProc args
   pure . bool (Left $ Failure pacmanFailure_1) (Right ()) $ ec == ExitSuccess
 
 -- | Run some `pacman` process, but only care about whether it succeeded.
 pacmanSuccess :: [T.Text] -> IO Bool
-pacmanSuccess = fmap (== ExitSuccess) . runProcess . setStderr closed . setStdout closed . proc "pacman" . map T.unpack
+pacmanSuccess = fmap (== ExitSuccess) . runProcess . setStderr closed . setStdout closed . pacmanProc . map T.unpack
 
 -- | Runs pacman silently and returns only the stdout.
 pacmanOutput :: [T.Text] -> IO BL.ByteString
-pacmanOutput = fmap (^. _2) . readProcess . proc "pacman" . map T.unpack
+pacmanOutput = fmap (^. _2) . readProcess . pacmanProc . map T.unpack
 
 -- | Runs pacman silently and returns the stdout as UTF8-decoded `Text` lines.
 pacmanLines :: [T.Text] -> IO [T.Text]


### PR DESCRIPTION
Force pacman to run with LC_ALL=C, so that its output is in English and can be parsed.

Fixes #543.