### PR TITLE
Ignore answer casing on yes/no questions

### DIFF
--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1443,7 +1443,7 @@ yesNoMessage = \case
     _          -> "[Y/n]"
 
 yesPattern :: Language -> [T.Text]
-yesPattern = \case
+yesPattern lang = map T.toCaseFold $ case lang of
     Polish     -> ["t", "tak"]
     Croatian   -> ["d", "da"]
     German     -> ["j", "ja"]

--- a/aura/lib/Aura/Utils.hs
+++ b/aura/lib/Aura/Utils.hs
@@ -202,7 +202,7 @@ yesNoPrompt ss msg = do
 
 -- | An empty response emplies "yes".
 isAffirmative :: Language -> T.Text -> Bool
-isAffirmative l t = T.null t || elem t (yesPattern l)
+isAffirmative l t = T.null t || elem (T.toCaseFold t) (yesPattern l)
 
 -- | Doesn't prompt when `--noconfirm` is used.
 optionalPrompt :: Settings -> (Language -> Doc AnsiStyle) -> IO Bool


### PR DESCRIPTION
Here's an extract of a surprising Aura interaction:

```
(...)
aura >>= `curl` can be used to download arbitrary scripts that aren't tracked by this PKGBUILD.
aura >>= Do you wish to quit the build process? [Y/n] Y
aura >>= AUR Packages:
tor-browser
aura >>= Continue? [Y/n] Y
aura >>= Installation manually aborted.
```

(note capital `Y` as the answer)

Allowing uppercase Y (and corresponding answers for other languages) makes the interface less confusing.